### PR TITLE
fix: ensures message set is reversible and properly treats None-values

### DIFF
--- a/aea/protocols/base.py
+++ b/aea/protocols/base.py
@@ -213,7 +213,12 @@ class Message:
         :param value: the value.
         """
         try:
-            setattr(self._slots, key, value)
+            if value is None and not hasattr(self._slots, key):
+                return
+            elif value is None and hasattr(self._slots, key):
+                delattr(self._slots, key)
+            else:
+                setattr(self._slots, key, value)
         except AttributeError as e:  # pragma: nocover
             raise ValueError(f"Field `{key}` is not supported {e}")
 

--- a/scripts/generate_ipfs_hashes.py
+++ b/scripts/generate_ipfs_hashes.py
@@ -222,7 +222,9 @@ class IPFSDaemon:
     def __enter__(self) -> None:
         """Run the ipfs daemon."""
         self.process = subprocess.Popen(  # nosec
-            ["ipfs", "daemon", "--offline"], stdout=subprocess.PIPE, env=os.environ.copy(),
+            ["ipfs", "daemon", "--offline"],
+            stdout=subprocess.PIPE,
+            env=os.environ.copy(),
         )
         print("Waiting for {} seconds the IPFS daemon to be up.".format(self.timeout))
         time.sleep(self.timeout)

--- a/tests/test_protocols/test_base.py
+++ b/tests/test_protocols/test_base.py
@@ -294,6 +294,21 @@ class TestBaseSerializations:
         self.message.set(key, value)
         assert self.message.get(key) == value
 
+    def test_set_unset(self):
+        """Test that the set method works and is reversible."""
+        self.message._body = {}  # clean values
+        key, value = "content", "temporary_value"
+        assert self.message.get(key) is None
+        assert not self.message.is_set(key)
+        self.message.set(key, None)
+        assert self.message.get(key) is None
+        assert not self.message.is_set(key)
+        self.message.set(key, value)
+        assert self.message.get(key) == value
+        self.message.set(key, None)
+        assert self.message.get(key) is None
+        assert not self.message.is_set(key)
+
     def test_body_setter(self):
         """Test the body setter."""
         m_dict = {"content": "data"}


### PR DESCRIPTION
## Proposed changes

This PR fixes an inconsistency in the `set` method of `Message` for None-values.

## Fixes

-

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

-