### PR TITLE
Bump plugins

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # Release History - open AEA
 
+## Plugins patch (2022-01-05)
+
+Plugins:
+- Fixes dynamic gas pricing on open-aea-ethereum
+- Improves daemon availability check in `IPFSDaemon` on open-aea-cli-ipfs
+- Bumps open-aea-cli-ipfs and open-aea-ethereum-ledger to `1.3.1`
+
+Docs: 
+- Removes reference to fetch.ai.
 ## 1.3.0 (2021-12-31)
 
 AEA:

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,4 +1,4 @@
-Our vision is that the AEA framework enables businesses of all sizes, from single independent developers to large corporations and consortiums, to create and deploy agent-based solutions in different domains, thus contributing to and advancing a decentralized agent economy as envisaged by Fetch.ai.
+Our vision is that the AEA framework enables businesses of all sizes, from single independent developers to large corporations and consortiums, to create and deploy agent-based solutions in different domains, thus contributing to and advancing a decentralized agent economy as envisaged by Valory.
 
 ## Open source technology for everyone
 

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.3.0",
+    version="1.3.1",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.3.0",
+    version="1.3.1",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",


### PR DESCRIPTION
## Plugins patch (2022-01-05)

Plugins:
- Fixes dynamic gas pricing on open-aea-ethereum
- Improves daemon availability check in `IPFSDaemon` on open-aea-cli-ipfs
- Bumps open-aea-cli-ipfs and open-aea-ethereum-ledger to `1.3.1`

Docs: 
- Removes reference to fetch.ai.