### PR TITLE
fix: delete rebuild_receipt

### DIFF
--- a/docs/api/plugins/aea_ledger_ethereum/ethereum.md
+++ b/docs/api/plugins/aea_ledger_ethereum/ethereum.md
@@ -66,15 +66,6 @@ get_gas_price_strategy(gas_price_strategy: Optional[str] = None, gas_price_api_k
 
 Get the gas price strategy.
 
-<a name="plugins.aea-ledger-ethereum.aea_ledger_ethereum.ethereum.rebuild_receipt"></a>
-#### rebuild`_`receipt
-
-```python
-rebuild_receipt(tx_receipt: JSONLike) -> JSONLike
-```
-
-Convert all tx receipt's event topics to HexBytes
-
 <a name="plugins.aea-ledger-ethereum.aea_ledger_ethereum.ethereum.SignedTransactionTranslator"></a>
 ## SignedTransactionTranslator Objects
 

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -316,13 +316,6 @@ def get_gas_price_strategy(
     return gas_station_gas_price_strategy
 
 
-def rebuild_receipt(tx_receipt: JSONLike) -> JSONLike:
-    """Convert all tx receipt's event topics to HexBytes"""
-    for i in range(len(tx_receipt["logs"])):  # type: ignore
-        tx_receipt["logs"][i]["topics"] = [HexBytes(topic) for topic in tx_receipt["logs"][i]["topics"]]  # type: ignore
-    return tx_receipt
-
-
 class SignedTransactionTranslator:
     """Translator for SignedTransaction."""
 
@@ -1336,9 +1329,6 @@ class EthereumApi(LedgerApi, EthereumHelper):
 
         except (TransactionNotFound, ValueError):  # pragma: nocover
             return dict(logs=[])
-
-        # Due to serialization, event topics must be converted again to HexBytes or processReceipt will fail
-        tx_receipt = rebuild_receipt(tx_receipt)
 
         transfer_logs = contract_instance.events.Transfer().processReceipt(tx_receipt)
 


### PR DESCRIPTION
## Proposed changes

After moving the receipt handling to the ethereum plugin, a call to rebuild_receipt that fixed message serialization issues is no longer needed and produces an exception when used.

## Fixes

Removes no longer needed code that produces an exception.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
