### PR TITLE
Support for remote `IPFS` registry

### DIFF
--- a/docs/api/plugins/aea_cli_ipfs/core.md
+++ b/docs/api/plugins/aea_cli_ipfs/core.md
@@ -9,8 +9,8 @@ Core components for `ipfs cli command`.
 ```python
 @click.group()
 @click.pass_context
-@click.option("--online", is_flag=True)
-ipfs(click_context: click.Context, online: bool) -> None
+@click.option("--offline", is_flag=True, default=False)
+ipfs(click_context: click.Context, offline: bool) -> None
 ```
 
 IPFS Commands

--- a/docs/api/plugins/aea_cli_ipfs/ipfs_utils.md
+++ b/docs/api/plugins/aea_cli_ipfs/ipfs_utils.md
@@ -3,6 +3,32 @@
 
 Ipfs utils for `ipfs cli command`.
 
+<a name="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.resolve_addr"></a>
+#### resolve`_`addr
+
+```python
+resolve_addr(addr: str) -> Tuple[str, ...]
+```
+
+Multiaddr resolver.
+
+**Arguments**:
+
+- `addr`: multiaddr string.
+
+**Returns**:
+
+http URL
+
+<a name="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.addr_to_url"></a>
+#### addr`_`to`_`url
+
+```python
+addr_to_url(addr: str) -> str
+```
+
+Convert address to url.
+
 <a name="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.IPFSDaemon"></a>
 ## IPFSDaemon Objects
 
@@ -20,7 +46,7 @@ Set up the IPFS daemon.
 #### `__`init`__`
 
 ```python
- | __init__(offline: bool = False, api_url: str = "http://127.0.0.1:5001/api/v0/id")
+ | __init__(offline: bool = False, api_url: str = "http://127.0.0.1:5001")
 ```
 
 Initialise IPFS daemon.
@@ -146,15 +172,25 @@ IPFS tool to add, publish, remove, download directories.
 #### `__`init`__`
 
 ```python
- | __init__(client_options: Optional[Dict] = None, offline: bool = True)
+ | __init__(addr: Optional[str] = None, offline: bool = True)
 ```
 
 Init tool.
 
 **Arguments**:
 
-- `client_options`: dict, options for ipfshttpclient instance.
+- `addr`: multiaddr string for IPFS client.
 - `offline`: ipfs mode.
+
+<a name="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.IPFSTool.addr"></a>
+#### addr
+
+```python
+ | @property
+ | addr() -> str
+```
+
+Node address
 
 <a name="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.IPFSTool.add"></a>
 #### add

--- a/plugins/aea-cli-ipfs/aea_cli_ipfs/core.py
+++ b/plugins/aea-cli-ipfs/aea_cli_ipfs/core.py
@@ -39,10 +39,10 @@ from aea.configurations.constants import CONFIG_FILE_TO_PACKAGE_TYPE
 
 @click.group()
 @click.pass_context
-@click.option("--online", is_flag=True)
-def ipfs(click_context: click.Context, online: bool) -> None:
+@click.option("--offline", is_flag=True, default=False)
+def ipfs(click_context: click.Context, offline: bool) -> None:
     """IPFS Commands"""
-    ipfs_tool = IPFSTool(offline=not online)
+    ipfs_tool = IPFSTool(offline=offline)
     click_context.obj = ipfs_tool
     try:
         ipfs_tool.check_ipfs_node_running()

--- a/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
+++ b/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
@@ -29,6 +29,56 @@ import ipfshttpclient  # type: ignore
 import requests
 
 
+DEFAULT_IPFS_URL = "/ip4/127.0.0.1/tcp/5001"
+ALLOWED_CONNECTION_TYPES = ("tcp",)
+ALLOWED_ADDR_TYPES = ("ip4", "dns")
+ALLOWED_PROTOCOL_TYPES = ("http", "https")
+MULTIADDR_FORMAT = "/{dns,dns4,dns6,ip4,ip6}/<host>/tcp/<port>/protocol"
+
+
+def _varify_attr(name: str, attr: str, allowed: Tuple[str, ...]) -> None:
+    """Varify various attributes of ipfs address."""
+
+    if attr not in allowed:
+        raise ValueError(f"{name} should be one of the {allowed}, provided: {attr}")
+
+
+def resolve_addr(addr: str) -> Tuple[str, ...]:
+    """
+    Multiaddr resolver.
+
+    :param addr: multiaddr string.
+    :return: http URL
+    """
+    _, addr_scheme, host, conn_type, *extra_data = addr.split("/")
+
+    if len(extra_data) > 2:  # pylint: disable=no-else-raise
+        raise ValueError(
+            f"Invalid multiaddr string provided, valid format: {MULTIADDR_FORMAT}. Provided: {addr}"
+        )
+    elif len(extra_data) == 2:
+        port, protocol, *_ = extra_data
+    elif len(extra_data) == 1:
+        (port,) = extra_data
+        protocol = "http"
+    else:
+        port = "5001"
+        protocol = "http"
+
+    _varify_attr("Address type", addr_scheme, ALLOWED_ADDR_TYPES)
+    _varify_attr("Connection", conn_type, ALLOWED_CONNECTION_TYPES)
+    _varify_attr("Protocol", protocol, ALLOWED_PROTOCOL_TYPES)
+
+    return addr_scheme, host, conn_type, port, protocol
+
+
+def addr_to_url(addr: str) -> str:
+    """Convert address to url."""
+
+    _, host, _, port, protocol = resolve_addr(addr)
+    return f"{protocol}://{host}:{port}"
+
+
 class IPFSDaemon:
     """
     Set up the IPFS daemon.
@@ -36,19 +86,20 @@ class IPFSDaemon:
     :raises Exception: if IPFS is not installed.
     """
 
-    def __init__(
-        self, offline: bool = False, api_url: str = "http://127.0.0.1:5001/api/v0/id"
-    ):
+    def __init__(self, offline: bool = False, api_url: str = "http://127.0.0.1:5001"):
         """Initialise IPFS daemon."""
+        if api_url.endswith("/"):
+            self.api_url = api_url + "api/v0/id"
+        else:
+            self.api_url = api_url + "/api/v0/id"
 
         self.process = None  # type: Optional[subprocess.Popen]
         self.offline = offline
-        self.api_url = api_url
         self._check_ipfs()
 
     @staticmethod
     def _check_ipfs() -> None:
-        # check we have ipfs
+        """Check if IPFS node is running."""
         res = shutil.which("ipfs")
         if res is None:
             raise Exception("Please install IPFS first!")
@@ -136,15 +187,29 @@ class DownloadError(BaseIPFSToolException):
 class IPFSTool:
     """IPFS tool to add, publish, remove, download directories."""
 
-    def __init__(self, client_options: Optional[Dict] = None, offline: bool = True):
+    _addr: Optional[str] = None
+
+    def __init__(self, addr: Optional[str] = None, offline: bool = True):
         """
         Init tool.
 
-        :param client_options: dict, options for ipfshttpclient instance.
+        :param addr: multiaddr string for IPFS client.
         :param offline: ipfs mode.
         """
-        self.client = ipfshttpclient.Client(**(client_options or {}))
-        self.daemon = IPFSDaemon(offline=offline)
+
+        if addr is not None:
+            _ = resolve_addr(addr)  # verify addr
+            self._addr = addr
+
+        self.client = ipfshttpclient.Client(addr=self.addr)
+        self.daemon = IPFSDaemon(offline=offline, api_url=addr_to_url(self.addr))
+
+    @property
+    def addr(self,) -> str:
+        """Node address"""
+        if self._addr is None:
+            self._addr = os.environ.get("OPEN_AEA_IPFS_ADDR", DEFAULT_IPFS_URL)
+        return self._addr
 
     def add(self, dir_path: str, pin: bool = True) -> Tuple[str, str, List]:
         """

--- a/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
+++ b/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
@@ -33,10 +33,11 @@ DEFAULT_IPFS_URL = "/ip4/127.0.0.1/tcp/5001"
 ALLOWED_CONNECTION_TYPES = ("tcp",)
 ALLOWED_ADDR_TYPES = ("ip4", "dns")
 ALLOWED_PROTOCOL_TYPES = ("http", "https")
-MULTIADDR_FORMAT = "/{dns,dns4,dns6,ip4,ip6}/<host>/tcp/<port>/protocol"
+MULTIADDR_FORMAT = "/{dns,dns4,dns6,ip4}/<host>/tcp/<port>/protocol"
+IPFS_NODE_CHECK_ENDPOINT = "/api/v0/id"
 
 
-def _varify_attr(name: str, attr: str, allowed: Tuple[str, ...]) -> None:
+def _verify_attr(name: str, attr: str, allowed: Tuple[str, ...]) -> None:
     """Varify various attributes of ipfs address."""
 
     if attr not in allowed:
@@ -65,9 +66,9 @@ def resolve_addr(addr: str) -> Tuple[str, ...]:
         port = "5001"
         protocol = "http"
 
-    _varify_attr("Address type", addr_scheme, ALLOWED_ADDR_TYPES)
-    _varify_attr("Connection", conn_type, ALLOWED_CONNECTION_TYPES)
-    _varify_attr("Protocol", protocol, ALLOWED_PROTOCOL_TYPES)
+    _verify_attr("Address type", addr_scheme, ALLOWED_ADDR_TYPES)
+    _verify_attr("Connection", conn_type, ALLOWED_CONNECTION_TYPES)
+    _verify_attr("Protocol", protocol, ALLOWED_PROTOCOL_TYPES)
 
     return addr_scheme, host, conn_type, port, protocol
 
@@ -88,11 +89,11 @@ class IPFSDaemon:
 
     def __init__(self, offline: bool = False, api_url: str = "http://127.0.0.1:5001"):
         """Initialise IPFS daemon."""
-        if api_url.endswith("/"):
-            self.api_url = api_url + "api/v0/id"
-        else:
-            self.api_url = api_url + "/api/v0/id"
 
+        if api_url.endswith("/"):
+            api_url = api_url[:-1]
+
+        self.api_url = api_url + IPFS_NODE_CHECK_ENDPOINT
         self.process = None  # type: Optional[subprocess.Popen]
         self.offline = offline
         self._check_ipfs()

--- a/plugins/aea-cli-ipfs/tests/test_aea_cli_ipfs.py
+++ b/plugins/aea-cli-ipfs/tests/test_aea_cli_ipfs.py
@@ -21,11 +21,11 @@ import os
 import re
 import sys
 from unittest.mock import patch
-from aea_cli_ipfs.ipfs_utils import addr_to_url, resolve_addr
 
 import click
 import ipfshttpclient  # type: ignore
 import pytest
+from aea_cli_ipfs.ipfs_utils import addr_to_url, resolve_addr
 from click.testing import CliRunner
 from urllib3.exceptions import NewConnectionError
 


### PR DESCRIPTION
## Proposed changes

This PR adds support for remote ipfs registry usage in the plugin and cli tool.

- [x] Make remote node address configurable from the environment
- [ ] Add support to publish packages on-chain using ipfs plugin

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules