### PR TITLE
Fix gas price strategy

### DIFF
--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -158,7 +158,9 @@ def estimate_priority_fee(
         fee_history_blocks, block_number, [fee_history_percentile]
     )
 
-    rewards = sorted([reward for reward in fee_history["reward"] if reward > 0])
+    # This is going to break if more percentiles are introduced in the future,
+    # i.e., `fee_history_percentile` param becomes a `List[int]`.
+    rewards = sorted([reward[0] for reward in fee_history["reward"] if reward[0] > 0])
     if len(rewards) == 0:
         return None
 


### PR DESCRIPTION
## Proposed changes

Repricing was failing with a message: 
```
'>' not supported between instances of 'list' and 'int'
```
The reason was because `estimate_priority_fee` was using the `fee_history` incorrectly. 
More specifically, `web3_object.eth.fee_history` returns a dict with the key "reward". 
This is a **two-dimensional** array of effective priority fees per gas at the requested block percentiles.
Instead, we were accessing the "reward" as if it were a single dimensional array.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a