### PR TITLE
[chore] : Fixed tests.py

### DIFF
--- a/docs/core-components-1.md
+++ b/docs/core-components-1.md
@@ -14,7 +14,7 @@ The following sections discuss the inner workings of the AEA framework and how i
 
 * `sender`: defines the sender address.
 
-* `protocol_id`: defines the id of the `Protocol`.
+* `protocol_specification_id`: defines the id of the `Protocol`.
 
 * `message`: is a bytes field which holds the `Message` in serialized form.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -135,9 +135,19 @@ pip install 'open-aea-ledger-ethereum'
 
 If the installation steps fail, it might be a dependency issue. Make sure you have followed all the relevant system specific steps above under `System Requirements`.
 
+## Setup Open-AEA Author
+
+To configure the aea with an author.
+
+``` bash
+aea init --local
+```
+
+
+
 ## Setup Open-AEA Components
 
-AEAs are composed from components. AEAs and AEA components can be developed by anyone and pushed to an <a href="https://ipfs.io/" target="_blank">IPFS registry</a> for others to use.
+AEAs are composed of components. AEAs and AEA components can be developed by anyone and pushed to an <a href="https://ipfs.io/" target="_blank">IPFS registry</a> for others to use.
 
 
 To load Valory packages please use <a href="https://subversion.apache.org/packages.html" target="_blank">SVN</a> to checkout the specific folders;
@@ -356,7 +366,7 @@ class TestEchoSkill(AEATestCase):
         sent_envelope = Envelope(
             to=self.agent_name,
             sender=sender_aea,
-            protocol_id=message.protocol_id,
+            protocol_specification_id=message.protocol_specification_id,
             message=DefaultSerializer().encode(message),
         )
 
@@ -367,7 +377,7 @@ class TestEchoSkill(AEATestCase):
 
         assert sent_envelope.to == received_envelope.sender
         assert sent_envelope.sender == received_envelope.to
-        assert sent_envelope.protocol_id == received_envelope.protocol_id
+        assert sent_envelope.protocol_specification_id == received_envelope.protocol_specification_id
         received_message = DefaultMessage.serializer.decode(received_envelope.message)
         assert message.content == received_message.content
 
@@ -393,7 +403,7 @@ Place the above code into a file <code>test.py</code> in your AEA project direct
 To run, execute the following:
 
 ``` bash
-pytest test.py
+pipenv run pytest test.py
 ```
 
 </details>

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -45,7 +45,7 @@ svn checkout https://github.com/valory-xyz/open-aea/trunk/packages packages
 sudo apt-get install python3.7-dev
 ```
 ``` bash 
-aea init
+aea init --local
 ```
 ``` bash
 Do you have a Registry account? [y/N]: n

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -144,7 +144,7 @@ info: Echo Behaviour: teardown method called.
 aea interact
 ```
 ``` bash
-pytest test.py
+pipenv run pytest test.py
 ```
 ``` bash
 aea delete my_first_aea

--- a/tests/test_docs/test_bash_yaml/test_demo_docs.py
+++ b/tests/test_docs/test_bash_yaml/test_demo_docs.py
@@ -43,9 +43,12 @@ class TestDemoDocs:
 
         bash_code_blocks = extract_code_blocks(filepath=md_path, filter_=filter_)
         for blocks in bash_code_blocks:
-            assert blocks in bash_file, "[{}]: FAILED. Code must be identical".format(
+            try:
+                assert blocks in bash_file, "[{}]: FAILED. Code must be identical".format(
                 filename
             )
+            except:
+                pass
         logger.info(
             f"[{filename}]: PASSED. Tested {len(bash_code_blocks)} '{filter_}' blocks."
         )

--- a/tests/test_docs/test_bash_yaml/test_demo_docs.py
+++ b/tests/test_docs/test_bash_yaml/test_demo_docs.py
@@ -43,12 +43,9 @@ class TestDemoDocs:
 
         bash_code_blocks = extract_code_blocks(filepath=md_path, filter_=filter_)
         for blocks in bash_code_blocks:
-            try:
-                assert blocks in bash_file, "[{}]: FAILED. Code must be identical".format(
+            assert blocks in bash_file, "[{}]: FAILED. Code must be identical".format(
                 filename
             )
-            except:
-                pass
         logger.info(
             f"[{filename}]: PASSED. Tested {len(bash_code_blocks)} '{filter_}' blocks."
         )

--- a/tests/test_docs/test_quickstart.py
+++ b/tests/test_docs/test_quickstart.py
@@ -2,6 +2,7 @@
 # ------------------------------------------------------------------------------
 #
 #   Copyright 2021-2022 Valory AG
+#   Copyright 2018-2021 Fetch.AI Limited
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tests/test_docs/test_quickstart.py
+++ b/tests/test_docs/test_quickstart.py
@@ -2,7 +2,7 @@
 # ------------------------------------------------------------------------------
 #
 #   Copyright 2021-2022 Valory AG
-#   Copyright 2018-2021 Fetch.AI Limited
+#   Copyright 2018-2019 Fetch.AI Limited
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tests/test_docs/test_quickstart.py
+++ b/tests/test_docs/test_quickstart.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021 Valory AG
-#   Copyright 2018-2019 Fetch.AI Limited
+#   Copyright 2021-2022 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tests/test_docs/test_quickstart.py
+++ b/tests/test_docs/test_quickstart.py
@@ -37,7 +37,7 @@ def test_correct_echo_string():
     """Test the echo string in the quickstart is using the correct protocol specification id."""
     file_path = Path(ROOT_DIR, "docs", "quickstart.md")
     bash_code_blocks = extract_code_blocks(filepath=file_path, filter_="bash")
-    echo_bloc = bash_code_blocks[17]
+    echo_bloc = bash_code_blocks[18]
     default_protocol_spec_id = echo_bloc.split(",")[2]
     assert (
         str(DefaultMessage.protocol_specification_id) == default_protocol_spec_id


### PR DESCRIPTION
This pr addresses the following issues;

- [](https://valory-xyz.github.io/open-aea/quickstart/)[](https://valory-xyz.github.io/open-aea/quickstart/)On [AEA quick start - open-aea](https://valory-xyz.github.io/open-aea/quickstart/)[](https://valory-xyz.github.io/open-aea/quickstart/)[](https://valory-xyz.github.io/open-aea/quickstart/) In the section "Alternatively: step by step installCreate a new AEA" an error appears "Author is not set up". Perhaps should be indicate to use aea init --local

- On [AEA quick start - open-aea](https://valory-xyz.github.io/open-aea/quickstart/) in the section "Writing tests" it's missing to say to install pytest in the virtual environment (even though I had to use "pipenv run pytest [test.py](http://test.py/)[](https://valory-xyz.github.io/open-aea/quickstart/)[](https://valory-xyz.github.io/open-aea/quickstart/)" inside the virtual environment to make it work...)



- On [AEA quick start - open-aea](https://valory-xyz.github.io/open-aea/quickstart/) file "[Test.py](http://test.py/)[](https://valory-xyz.github.io/open-aea/core-components-1/)[](https://valory-xyz.github.io/open-aea/core-components-1/)" contains an error: protocol_id should be protocol_specification_id (4 times)

- On [Core components - Part 1 - open-aea](https://valory-xyz.github.io/open-aea/core-components-1/) protocol_id should be protocol_specification_id in the description of the Envelope.

