### PR TITLE
fix: update make checks to use tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,14 +138,26 @@ v := $(shell pip -V | grep virtualenvs)
 .PHONY: checks
 checks:
 	make clean \
-	&& make static \
-	&& make lint \
-	&& make pylint \
-	&& make copyright \
-	&& make docs \
-	&& make api-docs \
-	&& make hashes \
-	&& make security \
+	&& tox -e bandit \
+	&& tox -e safety \
+	&& tox -e black \
+	&& tox -e isort \
+	&& tox -e flake8 \
+	&& tox -e darglint \
+	&& tox -e vulture \
+	&& tox -e mypy \
+	&& tox -e pylint \
+	&& tox -e liccheck \
+	&& tox -e hash_check -- --timeout 60.0 \
+	&& tox -e package_version_checks \
+	&& tox -e package_dependencies_checks \
+	&& tox -e check_generate_all_protocols \
+	&& tox -e docs \
+	&& tox -e check-copyright \
+	&& tox -e check_doc_links \
+	&& tox -e check_api_docs \
+	&& tox -e spell_check \
+	&& tox -e dependencies_check
 
 .PHONY: new_env
 new_env: clean


### PR DESCRIPTION
## Proposed changes

Most make linter targets are starting to differ from tox results. Since CI uses tox, I think it's a good thing we have coherence to avoid linting problems. I've updated make checks to perform most checks that CI does in this repo.

## Fixes

Updates make checks to run the same commands than CI does for linters.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
