### PR TITLE
Send tx unsafe

### DIFF
--- a/docs/api/plugins/aea_ledger_ethereum/ethereum.md
+++ b/docs/api/plugins/aea_ledger_ethereum/ethereum.md
@@ -617,6 +617,23 @@ Send a signed transaction and wait for confirmation.
 
 tx_digest, if present
 
+<a name="plugins.aea-ledger-ethereum.aea_ledger_ethereum.ethereum.EthereumApi.send_signed_transaction_unsafe"></a>
+#### send`_`signed`_`transaction`_`unsafe
+
+```python
+ | send_signed_transaction_unsafe(tx_signed: JSONLike) -> Optional[str]
+```
+
+Send a signed transaction. Might raise an error in case it fails for any reason.
+
+**Arguments**:
+
+- `tx_signed`: the signed transaction
+
+**Returns**:
+
+tx_digest, if an exception is not raised
+
 <a name="plugins.aea-ledger-ethereum.aea_ledger_ethereum.ethereum.EthereumApi.get_transaction_receipt"></a>
 #### get`_`transaction`_`receipt
 

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -1036,6 +1036,15 @@ class EthereumApi(LedgerApi, EthereumHelper):
         :param tx_signed: the signed transaction
         :return: tx_digest, if present
         """
+        return self.send_signed_transaction_unsafe(tx_signed)
+
+    def send_signed_transaction_unsafe(self, tx_signed: JSONLike) -> Optional[str]:
+        """
+        Send a signed transaction. Might raise an error in case it fails for any reason.
+
+        :param tx_signed: the signed transaction
+        :return: tx_digest, if an exception is not raised
+        """
         signed_transaction = SignedTransactionTranslator.from_dict(tx_signed)
         hex_value = self._api.eth.send_raw_transaction(  # pylint: disable=no-member
             signed_transaction.rawTransaction


### PR DESCRIPTION
## Proposed changes

Expose a method that sends a transaction and raises on error. We need this method in order to be able to handle it from the tx settlement skill and know why the transaction digest has not been returned and act properly.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a