### PR TITLE
Enable CLI option to substitude_env_vars on issue-certificates

### DIFF
--- a/aea/cli/issue_certificates.py
+++ b/aea/cli/issue_certificates.py
@@ -39,12 +39,26 @@ from aea.helpers.base import CertRequest, prepend_if_not_absolute
 
 @click.command()
 @password_option()
+@click.option(
+    "--aev",
+    "apply_environment_variables",
+    required=False,
+    is_flag=True,
+    default=False,
+    help="Populate Agent configs from Environment variables.",
+)
 @click.pass_context
 @check_aea_project
-def issue_certificates(click_context: click.Context, password: Optional[str]) -> None:
+def issue_certificates(
+    click_context: click.Context,
+    apply_environment_variables: bool,
+    password: Optional[str],
+) -> None:
     """Issue certificates for connections that require them."""
     ctx = cast(Context, click_context.obj)
-    agent_config_manager = AgentConfigManager.load(ctx.cwd)
+    agent_config_manager = AgentConfigManager.load(
+        ctx.cwd, substitude_env_vars=apply_environment_variables,
+    )
     issue_certificates_(ctx.cwd, agent_config_manager, password=password)
 
 


### PR DESCRIPTION
## Proposed changes

Add click option `--aev` (apply_environment_variables)

Required to enable the issuance of a certificate for the libp2p connection. Specifically, the `issue-certificates` command is needed in the deployments on the consensus-algortihms repo in [start.sh](https://github.com/valory-xyz/consensus-algorithms/blob/0e2b0b8173e73e100e48299c149bc1b67bbf2d80/deployments/Dockerfiles/open_aea/start.sh#L30-L33) to generate the proof of representation.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

