### PR TITLE
Feat/v1.8.0

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -267,6 +267,13 @@ acn
 args
 open-aea
 cleanup
+gc
+memray
+pluging
+cli
+mkdocs
+ipfs
+commandline
  - docs/language-agnostic-definition.md
 fetchai
 protocol_id

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,37 @@
 # Release History - open AEA
 
 
+## 1.8.0 (2022-05-12)
+
+AEA:
+- Extends the run command to print all available addresses at the AEA start up.
+- Introduces support for usage of hashes as a part of the `PublicId`
+- Adds support for IPFS based registry
+- Introduces dialogue cleanup
+- Adds support for removing the temporal `None` values in the dialogue label 
+- Updated the profiler to
+  - Removing the unwanted variables in profiling
+  - Set counters also in the destructor
+  - Only iterate the gc one
+  - Use types blacklist
+  - Get info from all objects
+- Adds support for memray in the profiler
+- Ports the `generate_all_protocols.py` and `generate_ipfs_hashes.py` to `aea.cli` as a command line tools.
+- Adds support for the usage of environment variables in `issue-certificates` command.
+
+Pluging:
+-  Updates IPFS cli plugin tool to support remote registry and extended `PublicId`
+
+Packages:
+- Updated tendermint protocol for config sharing
+
+Chores:
+- Adds support for IPFS in CI for windows based environments
+- Profile parser checks for non empty data before plotting
+- The paths to download the packages folder with svn are now pointing to the version tag rather than main.
+- Adds the missing search plugin for mkdocs.
+- Adds new functionality to the log parser to add an extra plot with common objects in the garbage collector.
+
 ## 1.7.0 (2022-04-15)
 
 AEA:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-aea` are currently being suppo
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `1.7.x`   | :white_check_mark: |
-| `< 1.7.0` | :x:                |
+| `1.8.x`   | :white_check_mark: |
+| `< 1.8.0` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.7.0
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.8.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.7.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.8.0/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.7.0
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.8.0
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -152,7 +152,7 @@ AEAs are composed of components. AEAs and AEA components can be developed by any
 
 To load Valory packages please use <a href="https://subversion.apache.org/packages.html" target="_blank">SVN</a> to checkout the specific folders;
 ```bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.7.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.8.0/packages packages
 ```
 
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,6 +7,12 @@ Below we describe the additional manual steps required to upgrade between differ
 
 # Open AEA
 
+## `v1.7.0` to `1.8.0`
+
+No backwards incompatible changes.
+
+Plugins from previous versions are not compatible anymore.
+
 ## `v1.6.0` to `v1.7.0`
 
 No backwards incompatible changes.

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.7.0
+RUN pip install --upgrade --force-reinstall aea[all]==1.8.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
         - Exec Timeout: 'api/helpers/exec_timeout.md'
         - File IO: 'api/helpers/file_io.md'
         - File Lock: 'api/helpers/file_lock.md'
+        - Git: api/helpers/git.md
         - HttpRequests: 'api/helpers/http_requests.md'
         - Install Dependency: 'api/helpers/install_dependency.md'
         - IO: 'api/helpers/io.md'
@@ -160,6 +161,7 @@ nav:
         - Pipe: 'api/helpers/pipe.md'
         - Preferences:
           - Base: 'api/helpers/preference_representations/base.md'
+        - Profiler Type Blacklist: api/helpers/profiler_type_black_list.md
         - Profiling: 'api/helpers/profiling.md'
         - Search:
           - Generic: 'api/helpers/search/generic.md'
@@ -180,6 +182,7 @@ nav:
       - Manager:
         - Manager: 'api/manager/manager.md'
         - Project: 'api/manager/project.md'
+        - Helpers:  api/manager/helpers.md
         - Utils: 'api/manager/utils.md'
       - Protocols:
         - Base: 'api/protocols/base.md'

--- a/packages/fetchai/protocols/contract_api/__init__.py
+++ b/packages/fetchai/protocols/contract_api/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the contract_api protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.fetchai.protocols.contract_api.message import ContractApiMessage

--- a/packages/fetchai/protocols/contract_api/protocol.yaml
+++ b/packages/fetchai/protocols/contract_api/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmYJqcqfbCFE3LHMgok2xkP9z8myB9NNZsm6iR6NXh2HQF
-  __init__.py: Qmb7JgyFrHFoLCEBzS4LiTRr7YNAaKE5HnFmEpwYm8vMHD
+  __init__.py: QmbNML14edvpZxQg3MRhP8YfEvZrqa6W4ALedydWWKpJGY
   contract_api.proto: QmVezvQ3vgN19nzJD1CfgvjHxjdaP4yLUSwaQDMQq85vUZ
   contract_api_pb2.py: QmRp7JBW1HQGwShSagVLTpvQvEkQPqAZLqnTT2HkBpXBuk
   custom_types.py: QmW9Ju9GnYc8A7sbG8RvR8NnTCf5sVfycYqotN6WZb76LG

--- a/packages/fetchai/protocols/default/__init__.py
+++ b/packages/fetchai/protocols/default/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the default protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.fetchai.protocols.default.message import DefaultMessage

--- a/packages/fetchai/protocols/default/protocol.yaml
+++ b/packages/fetchai/protocols/default/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmNN1eJSSeAGs4uny1tqWkeQwyr6SVV2QgKAoPz18W5jnV
-  __init__.py: QmNwGUYMk7SK7G8JnHgxJrQD9soPq2KyYP5tRaoTHh1Kr6
+  __init__.py: Qmf3MG4Dd6xomxvpi7kk3gczHw4sz63nCE4zvTGFQ3YqaB
   custom_types.py: QmVbmxfpiHM8xDvsRvytPr4jmjD5Ktc5171fweYGBkXvBd
   default.proto: QmWYzTSHVbz7FBS84iKFMhGSXPxay2mss29vY7ufz2BFJ8
   default_pb2.py: QmRjBnFfnHHPygYmSdXfVp6A2FZ7PtrYKpdwTXxMYLwEGK

--- a/packages/fetchai/protocols/fipa/__init__.py
+++ b/packages/fetchai/protocols/fipa/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the fipa protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.fetchai.protocols.fipa.message import FipaMessage

--- a/packages/fetchai/protocols/fipa/protocol.yaml
+++ b/packages/fetchai/protocols/fipa/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmfZxjMzApLKdff7s77G6RKqsmXLdc18yLoMLpDsoV2C8c
-  __init__.py: QmZjSzRQzJt2ArJjqBtVAfwb92AAkt3ztYC5SEArsgSpFT
+  __init__.py: QmRPVXtoxePsMzTX9cyiv4B23uA2JbbSJp15LARK31byiw
   custom_types.py: Qmf72KRbkNsxxAHwMtkmJc5TRL23fU7AuzJAdSTftckwJQ
   dialogues.py: QmRvjJDEbGyhTh1cF6kSbzf45F7bEXFpWMnTw4Yf2TBymL
   fipa.proto: QmS7aXZ2JoG3oyMHWiPYoP9RJ7iChsoTC9KQLsj6vi3ejR

--- a/packages/fetchai/protocols/gym/__init__.py
+++ b/packages/fetchai/protocols/gym/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the gym protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.fetchai.protocols.gym.message import GymMessage

--- a/packages/fetchai/protocols/gym/protocol.yaml
+++ b/packages/fetchai/protocols/gym/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmSrL3oujtXaSgrbxQzYD12oHjb5d55kNSFiZ4SA3jSNj1
-  __init__.py: QmeGCQdcUsT8xccZP5cyuTWHVzZ1siRNRSS17BSJPKYw8j
+  __init__.py: QmQjwNciUNKKpjqdtEQvdAkXQTmj71wi7xaU8YXHG7BbfV
   custom_types.py: QmTQSizkRh6awSk4J2cPGjidMcZ356bTyYxNG2HSgfkj9B
   dialogues.py: QmYPuD9fkw6Rowu6eXJV5yaCjUe9jX9Ji3JSx3kQ6xaDKK
   gym.proto: QmSYD1qtmNwKnfuTUtPGzbfW3kww4viJ714aRTPupLdV62

--- a/packages/fetchai/protocols/http/__init__.py
+++ b/packages/fetchai/protocols/http/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the http protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.fetchai.protocols.http.message import HttpMessage

--- a/packages/fetchai/protocols/http/protocol.yaml
+++ b/packages/fetchai/protocols/http/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmVzD8i4VPm36TKUn8yfuswTJbeaMBSuSqb4amokQCDc9d
-  __init__.py: QmdRid99mUpgCiiAPMTvrJzTnA5ZNa9yTAiYm5RdDdwUNS
+  __init__.py: QmbHWAKiax5aryjaBL5Y4oYEQ1ZQfXdjnmc2ysH18FpTHs
   dialogues.py: Qmc7ZyMiofAp95bwty32Ty3bgtEuWN2A76LWhKeYVpDNWj
   http.proto: QmfJj4aoNpVCZs8HsQNmf1Zx2y8b9JbuPG2Dysow4LwRQU
   http_pb2.py: QmeQd42QbVdvnjuW1Eqz9UGxn2GsdMgb1Ew4Vb52xN9DKk

--- a/packages/fetchai/protocols/ledger_api/__init__.py
+++ b/packages/fetchai/protocols/ledger_api/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the ledger_api protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.fetchai.protocols.ledger_api.message import LedgerApiMessage

--- a/packages/fetchai/protocols/ledger_api/protocol.yaml
+++ b/packages/fetchai/protocols/ledger_api/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmUjEQqcfDm1F1ARmG2fVp9J6nBdeHrXQiFAPKawtgR1g6
-  __init__.py: QmXGf98pYAckTzbSwRkbJqjrhLYZSYcwusLBDUzrqp7Usb
+  __init__.py: QmW5AeEb1trFWBwmdEfP3SaA1Bn5Mz6sedcGyj8qf6wLaX
   custom_types.py: QmT3aUh6HP2LaD5HziEEvjxVpv4G671P5EKV3rfh77epgy
   dialogues.py: QmcYRdn3UNeyCD8aSrcrc19Witznb2LqeMwyNRCVFkBmDb
   ledger_api.proto: QmdSbtU1eXT1ZLFZkdCzTpBD8NyDMWgiA4MJBoHJLdCkz3

--- a/packages/fetchai/protocols/oef_search/__init__.py
+++ b/packages/fetchai/protocols/oef_search/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the oef_search protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.fetchai.protocols.oef_search.message import OefSearchMessage

--- a/packages/fetchai/protocols/oef_search/protocol.yaml
+++ b/packages/fetchai/protocols/oef_search/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmRzU4RAYqfnDKxHv6iH9hmbG59uEJequ6CA4rwwbvgjuW
-  __init__.py: QmVVHDD8H5gv6vTSW8dReoZfRKbGS7j4surWcLKDF7V6QK
+  __init__.py: QmUcC3tQgGdYqnszd7RCpGPDdR9ZxYDEnHDe9t46zSzBfb
   custom_types.py: QmeyJUULbC8HuNbaU8kmQYau9BJo6gBkTTsZPFmk8ngtPf
   dialogues.py: QmTQL6ccCPnYCwaFQiJGtuWQx5SbCXmukUaPainmreyFBZ
   message.py: QmRAqT4QhYP4b3o1HbU1NcU6hpzoxRbyzv4PEYwVZbnV9T

--- a/packages/fetchai/protocols/state_update/__init__.py
+++ b/packages/fetchai/protocols/state_update/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the state_update protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.fetchai.protocols.state_update.message import StateUpdateMessage

--- a/packages/fetchai/protocols/state_update/protocol.yaml
+++ b/packages/fetchai/protocols/state_update/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmXUyoQ3NTF9EBSSk7ENNRbCANwABKJvfbrKi2Pmoc2JkT
-  __init__.py: QmW3swmhMvVBEQcxtx1RA4srhBfMGtrgP6PpBdAxB9xjJS
+  __init__.py: QmaPx2HB9zQtpHiMCa6c4uezVxAkHBbL8PokxJid5vqvjc
   dialogues.py: QmPKGuXmBsC62b4WGojPrYNH1cXSWj4ir5oAS9v3xfZvKa
   message.py: QmP9uR4AvQv1A1Fx41bVC3cbQj4veRuEY1yERCdV8HvcQj
   serialization.py: QmZTJMieof5uL3zDQXRMnZso8Fs1CqgNn4Tua7DqihkFdk

--- a/packages/fetchai/protocols/tac/__init__.py
+++ b/packages/fetchai/protocols/tac/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the tac protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.fetchai.protocols.tac.message import TacMessage

--- a/packages/fetchai/protocols/tac/protocol.yaml
+++ b/packages/fetchai/protocols/tac/protocol.yaml
@@ -9,7 +9,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmRKpjkcyW9vQUfVQFAZqTc8tXj6MeKQvwFseCaZcMt4AK
-  __init__.py: QmcL5JtER7ZJKn4kGLNufw4Vwu8cigAViTbEWGbUAQZyhY
+  __init__.py: QmP1uZbzmKvNKP182rXXoGe4jTeZThLY3Pp3fW2Ty7BEk1
   custom_types.py: QmNzs8yaVU3xL7XKA7WZWHyuEctAdj5UJLnZfompFvXf1i
   dialogues.py: QmPmqYyKNJLrfS2kyuujoK4qMzeyJ9yfEQmWeETXXgZ7Lr
   message.py: QmSSGEPx2kR2Q1bdXFCKxQAkt9RDXxwhoWeozf76MY2Kce

--- a/packages/open_aea/protocols/signing/__init__.py
+++ b/packages/open_aea/protocols/signing/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the signing protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.open_aea.protocols.signing.message import SigningMessage

--- a/packages/open_aea/protocols/signing/protocol.yaml
+++ b/packages/open_aea/protocols/signing/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmTym1GXLScdeJVd4WsLfgVpn8ouPX6ddwi1LLcTX1rPTg
-  __init__.py: QmV2kYq4xizLy78pc1ndeRDGoc17gYhBtWfR5sQgpPRZ4p
+  __init__.py: QmQ37f4Q8pptdCTy7LogaP3ZVE4yQV5ah2eiG5SnbHnRnu
   custom_types.py: QmSjuy9e7KkzhyGDr8eB1cjmjTAkBoNQjb1YXjBk5B36d1
   dialogues.py: QmRaEqaneDaGd69od629EW4FmXakaQfbdXKNCfxsDhbHcG
   message.py: QmREhvXNi6bEc4yCnSs172wPnBb3YpE1nuRdSSD9Q6XMfM

--- a/packages/valory/protocols/acn/__init__.py
+++ b/packages/valory/protocols/acn/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the acn protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.valory.protocols.acn.message import AcnMessage

--- a/packages/valory/protocols/acn/protocol.yaml
+++ b/packages/valory/protocols/acn/protocol.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmZ59igTs2SKsMDHzuew8gfGdqjW1vNZ3DxBDqWLnDd6XD
-  __init__.py: QmRP6JEvAjvBu862ri2RXrSwZHkVrgdWCq49Jnrs3XXALs
+  __init__.py: QmXYFwr8WkxXtRgkBaELTKRhZqWQhzKLhmoV8iKudChShi
   acn.proto: QmVWvXETUNe7QZTvBgzwpofNP3suFthwyxbTVUqSx8mdnE
   acn_pb2.py: Qmf3HYmJtGwugpCuWSmJEDVHwZcnCF6BWmeEouUSpBRs45
   custom_types.py: QmS9xN5EPy8pZRbwpUdewH7TocNGCx7xv3GwupxSQRRVgM

--- a/packages/valory/protocols/tendermint/__init__.py
+++ b/packages/valory/protocols/tendermint/__init__.py
@@ -20,7 +20,7 @@
 """
 This module contains the support resources for the tendermint protocol.
 
-It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.7.0`.
+It was created with protocol buffer compiler version `libprotoc 3.19.4` and aea version `1.8.0`.
 """
 
 from packages.valory.protocols.tendermint.message import TendermintMessage

--- a/packages/valory/protocols/tendermint/protocol.yaml
+++ b/packages/valory/protocols/tendermint/protocol.yaml
@@ -9,7 +9,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: QmU7EMLyBUhLyGM5XYAC8UcFZLzT8Wy8PmUBtZREeRiuj1
-  __init__.py: QmR6Lqn5Gw6yLCGC5ToxkmtZCAmJppMSSvWpAwBUSvGozK
+  __init__.py: QmbyiNr453jFEEh57wSAsPA4Nat6647mwXcvvJVnfKSqwF
   custom_types.py: QmY3fU6xiCSQyzRmeQgAkgzLa1YNhCwcdoie8v6USEsU4F
   dialogues.py: QmVo2K5ModwfF1J562M6ZiGkCdogdB16u33NBvwmBqx6vm
   message.py: QmeHjyNVGkb6T6UwZBxdBajmGR4wQrUycZdSePAkA6Zibo

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.7.0",
+    version="1.8.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.7.0",
+    version="1.8.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.7.0",
+    version="1.8.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.7.0",
+    version="1.8.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.7.0 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.8.0 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.7.0 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.8.0 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -37,7 +37,7 @@ svn export https://github.com/valory-xyz/open-aea.git/trunk/packages
 pip install open-aea[all]
 ```
 ```
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.7.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.8.0/packages packages
 ```
 
 

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.7.0
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.8.0
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: 1.8.0

## Release details

AEA:
- Extends the run command to print all available addresses at the AEA start up.
- Introduces support for usage of hashes as a part of the `PublicId`
- Adds support for IPFS based registry
- Introduces dialogue cleanup
- Adds support for removing the temporal `None` values in the dialogue label 
- Updated the profiler to
  - Removing the unwanted variables in profiling
  - Set counters also in the destructor
  - Only iterate the gc one
  - Use types blacklist
  - Get info from all objects
- Adds support for memray in the profiler
- Ports the `generate_all_protocols.py` and `generate_ipfs_hashes.py` to `aea.cli` as a command line tools.
- Adds support for the usage of environment variables in `issue-certificates` command.

Pluging:
-  Updates IPFS cli plugin tool to support remote registry and extended `PublicId`

Packages:
- Updated tendermint protocol for config sharing

Chores:
- Adds support for IPFS in CI for windows based environments
- Profile parser checks for non empty data before plotting
- The paths to download the packages folder with svn are now pointing to the version tag rather than main.
- Adds the missing search plugin for mkdocs.
- Adds new functionality to the log parser to add an extra plot with common objects in the garbage collector.

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [x] Lint and unit tests pass locally and in CI
- [x] I have checked the fingerprint hashes are correct by running (`aea hash all --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.
