### PR TITLE
Fix default remote registry issue

### DIFF
--- a/aea/cli/init.py
+++ b/aea/cli/init.py
@@ -101,7 +101,9 @@ def do_init(
         update_cli_config({AUTHOR_KEY: author})
 
         if registry_type == REGISTRY_LOCAL:
-            _registry_init_local()
+            if default_remote_registry is None:
+                default_remote_registry = REMOTE_IPFS
+            _registry_init_local(default_remote_registry)
         else:
             default_remote_registry = validate_remote_registry_type(
                 default_remote_registry
@@ -122,10 +124,9 @@ def do_init(
     click.echo(success_msg)
 
 
-def _registry_init_local() -> None:
+def _registry_init_local(default_remote_registry: str = REMOTE_IPFS) -> None:
     """Initialize ipfs local"""
-    registry_config = DEFAULT_REGISTRY_CONFIG.copy()
-    registry_config["default"] = REGISTRY_LOCAL
+    registry_config = _set_registries(REGISTRY_LOCAL, default_remote_registry)
     update_cli_config({REGISTRY_CONFIG_KEY: registry_config})
 
 
@@ -144,11 +145,9 @@ def _registry_init_remote(
 
 def _registry_init_ipfs(ipfs_node: Optional[str]) -> None:
     """Initialize ipfs registry"""
-    registry_config = DEFAULT_REGISTRY_CONFIG.copy()
-    registry_config["default"] = REGISTRY_REMOTE
-    registry_config["settings"][REGISTRY_REMOTE]["default"] = REMOTE_IPFS
-    registry_config["settings"][REGISTRY_REMOTE][REMOTE_IPFS]["ipfs_node"] = ipfs_node
 
+    registry_config = _set_registries(REGISTRY_REMOTE, REMOTE_IPFS)
+    registry_config["settings"][REGISTRY_REMOTE][REMOTE_IPFS]["ipfs_node"] = ipfs_node
     update_cli_config({REGISTRY_CONFIG_KEY: registry_config})
 
 
@@ -159,10 +158,7 @@ def _registry_init_http(username: str, no_subscribe: bool) -> None:
     :param username: the user name
     :param no_subscribe: bool flag for developers subscription skip on register.
     """
-    registry_config = DEFAULT_REGISTRY_CONFIG.copy()
-    registry_config["default"] = REGISTRY_REMOTE
-    registry_config["settings"][REGISTRY_REMOTE]["default"] = REMOTE_HTTP
-
+    registry_config = _set_registries(REGISTRY_REMOTE, REMOTE_HTTP)
     update_cli_config({REGISTRY_CONFIG_KEY: registry_config})
 
     if username is not None and is_auth_token_present():
@@ -185,3 +181,14 @@ def _registry_init_http(username: str, no_subscribe: bool) -> None:
                 )
 
             do_register(username, email, password, password_confirmation, no_subscribe)
+
+
+def _set_registries(
+    default_registry: str = REGISTRY_LOCAL, default_remote_registry: str = REMOTE_IPFS
+) -> None:
+    """Set registry values."""
+    registry_config = DEFAULT_REGISTRY_CONFIG.copy()
+    registry_config["default"] = default_registry
+    registry_config["settings"][REGISTRY_REMOTE]["default"] = default_remote_registry
+
+    return registry_config

--- a/aea/cli/init.py
+++ b/aea/cli/init.py
@@ -20,7 +20,7 @@
 
 """Implementation of the 'aea init' subcommand."""
 
-from typing import Optional
+from typing import Dict, Optional
 
 import click
 
@@ -185,7 +185,7 @@ def _registry_init_http(username: str, no_subscribe: bool) -> None:
 
 def _set_registries(
     default_registry: str = REGISTRY_LOCAL, default_remote_registry: str = REMOTE_IPFS
-) -> None:
+) -> Dict:
     """Set registry values."""
     registry_config = DEFAULT_REGISTRY_CONFIG.copy()
     registry_config["default"] = default_registry

--- a/aea/cli/utils/click_utils.py
+++ b/aea/cli/utils/click_utils.py
@@ -235,7 +235,7 @@ def registry_flag(mark_default: bool = True) -> Callable:
 
 
 def remote_registry_flag(mark_default: bool = True) -> Callable:
-    """Choice of one flag between: '--local/--remote'."""
+    """Choice of one flag between: '--ipfs/--http'."""
 
     default_registry = (
         get_or_create_cli_config()
@@ -250,14 +250,14 @@ def remote_registry_flag(mark_default: bool = True) -> Callable:
             "--ipfs",
             "remote_registry",
             flag_value=REMOTE_IPFS,
-            help="To use a local registry.",
+            help="To use an IPFS registry.",
             default=(REMOTE_IPFS == default_registry) and mark_default,
         )(f)
         f = option(
             "--http",
             "remote_registry",
             flag_value=REMOTE_HTTP,
-            help="To use a remote registry.",
+            help="To use an HTTP registry.",
             default=(REMOTE_HTTP == default_registry) and mark_default,
         )(f)
         return f

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -400,7 +400,7 @@ def test_fetch_twice_remote():
                         "--registry-path",
                         PACKAGES_DIR,
                         "fetch",
-                        "--remote",
+                        "--local",
                         "fetchai/my_first_aea",
                     ],
                     standalone_mode=False,

--- a/tests/test_cli/test_publish.py
+++ b/tests/test_cli/test_publish.py
@@ -252,6 +252,8 @@ class TestPublishRemotellyWithDeps(AEATestCaseEmpty):
             ClickException, match=r"Package not found in remote registry"
         ) as e, mock.patch(
             "aea.cli.publish.get_package_meta", side_effect=ClickException("expected"),
+        ), mock.patch(
+            "aea.cli.publish.get_default_remote_registry", new=lambda: REMOTE_HTTP
         ):
             self.invoke("publish", "--remote")
         assert "--push-missing" in str(e)
@@ -260,6 +262,8 @@ class TestPublishRemotellyWithDeps(AEATestCaseEmpty):
         with mock.patch(
             "aea.cli.publish.get_package_meta",
             side_effect=[ClickException("expected")] + [mock.DEFAULT] * 100,
+        ), mock.patch(
+            "aea.cli.publish.get_default_remote_registry", new=lambda: REMOTE_HTTP
         ):
             self.invoke("publish", "--remote", "--push-missing")
 


### PR DESCRIPTION
## Proposed changes

We were not setting the default remote registry correctly when initialising the aea cli tool. This PR fixes that

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

