### PR TITLE
Skip import statements made in `try/except` blocks

### DIFF
--- a/scripts/check_imports_and_dependencies.py
+++ b/scripts/check_imports_and_dependencies.py
@@ -90,7 +90,20 @@ class ImportsTool:
         with open(pyfile, "r") as f:
             statements = f.read()
         instructions = dis.get_instructions(statements)  # type: ignore
-        imports = [i for i in instructions if "IMPORT" in i.opname]
+        imports = []
+        is_try_except_block = False
+        for im in instructions:
+            if "SETUP_FINALLY" in im.opname:
+                is_try_except_block = True
+
+            if "POP_EXCEPT" in im.opname:
+                is_try_except_block = False
+
+            if is_try_except_block:
+                continue
+
+            if "IMPORT" in im.opname:
+                imports.append(im)
 
         grouped: Dict[str, List[str]] = defaultdict(list)
         for instr in imports:


### PR DESCRIPTION
## Proposed changes

This PR modifies the `scripts/check_imports_and_dependencies.py` to skip the import statements made in a `try/except` block

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/agents-aea/blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
