### PR TITLE
pywin32 versioning for 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ base_deps = [
 ]
 
 if os.name == "nt" or os.getenv("WIN_BUILD_WHEEL", None) == "1":
-    base_deps.append("pywin32==300")
+    base_deps.append("pywin32>=300,<305")
 
 here = os.path.abspath(os.path.dirname(__file__))
 about: Dict[str, str] = {}


### PR DESCRIPTION
## Proposed changes

I believe that if a release was made from this branch, then we would be able to pass the failing tests

Relax compatibility of pywin32

