### PR TITLE
[WIP] Add `--aev` flag on `aea config` command

### DIFF
--- a/aea/cli/config.py
+++ b/aea/cli/config.py
@@ -43,11 +43,21 @@ def config(click_context: click.Context) -> None:  # pylint: disable=unused-argu
 
 @config.command()
 @click.argument("JSON_PATH", required=True)
+@click.option(
+    "--aev",
+    "apply_environment_variables",
+    required=False,
+    is_flag=True,
+    default=False,
+    help="Populate Agent configs from Environment variables.",
+)
 @pass_ctx
-def get(ctx: Context, json_path: str) -> None:
+def get(ctx: Context, apply_environment_variables: bool, json_path: str) -> None:
     """Get a field."""
     try:
-        agent_config_manager = AgentConfigManager.load(ctx.cwd)
+        agent_config_manager = AgentConfigManager.load(
+            ctx.cwd, apply_environment_variables
+        )
         value = agent_config_manager.get_variable(json_path)
     except (ValueError, AEAException) as e:
         raise ClickException(*e.args)

--- a/aea/cli/config.py
+++ b/aea/cli/config.py
@@ -68,13 +68,27 @@ def get(ctx: Context, json_path: str) -> None:
 )
 @click.argument("JSON_PATH", required=True)
 @click.argument("VALUE", required=True, type=str)
+@click.option(
+    "--aev",
+    "apply_environment_variables",
+    required=False,
+    is_flag=True,
+    default=False,
+    help="Populate Agent configs from Environment variables.",
+)
 @pass_ctx
 def set_command(
-    ctx: Context, json_path: str, value: str, type_: Optional[str],
+    ctx: Context,
+    json_path: str,
+    value: str,
+    apply_environment_variables: bool,
+    type_: Optional[str],
 ) -> None:
     """Set a field."""
     try:
-        agent_config_manager = AgentConfigManager.load(ctx.cwd)
+        agent_config_manager = AgentConfigManager.load(
+            ctx.cwd, apply_environment_variables
+        )
 
         current_value = None
         with contextlib.suppress(VariableDoesNotExist):

--- a/aea/test_tools/test_cases.py
+++ b/aea/test_tools/test_cases.py
@@ -123,7 +123,11 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
 
     @classmethod
     def set_config(
-        cls, dotted_path: str, value: Any, type_: Optional[str] = None, aev: bool = False
+        cls,
+        dotted_path: str,
+        value: Any,
+        type_: Optional[str] = None,
+        aev: bool = False,
     ) -> Result:
         """
         Set a config.
@@ -133,28 +137,19 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
         :param dotted_path: str dotted path to config param.
         :param value: a new value to set.
         :param type_: the type
+        :param aev: use the environment variables
 
         :return: Result
         """
         if type_ is None:
             type_ = type(value).__name__
 
-        cmd = [
-            "config",
-            "set",
-            dotted_path,
-            str(value),
-            "--type",
-            type_
-        ]
+        cmd = ["config", "set", dotted_path, str(value), "--type", type_]
 
         if aev:
             cmd.append("--aev")
 
-        return cls.run_cli_command(
-            *cmd,
-            cwd=cls._get_cwd(),
-        )
+        return cls.run_cli_command(*cmd, cwd=cls._get_cwd(),)
 
     @classmethod
     def nested_set_config(cls, dotted_path: str, value: Any) -> None:

--- a/aea/test_tools/test_cases.py
+++ b/aea/test_tools/test_cases.py
@@ -146,6 +146,7 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
             str(value),
             "--type",
             type_,
+            "--aev",
             cwd=cls._get_cwd(),
         )
 

--- a/aea/test_tools/test_cases.py
+++ b/aea/test_tools/test_cases.py
@@ -123,7 +123,7 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
 
     @classmethod
     def set_config(
-        cls, dotted_path: str, value: Any, type_: Optional[str] = None
+        cls, dotted_path: str, value: Any, type_: Optional[str] = None, aev: bool = False
     ) -> Result:
         """
         Set a config.
@@ -139,14 +139,20 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
         if type_ is None:
             type_ = type(value).__name__
 
-        return cls.run_cli_command(
+        cmd = [
             "config",
             "set",
             dotted_path,
             str(value),
             "--type",
-            type_,
-            "--aev",
+            type_
+        ]
+
+        if aev:
+            cmd.append("--aev")
+
+        return cls.run_cli_command(
+            *cmd,
             cwd=cls._get_cwd(),
         )
 

--- a/docs/api/test_tools/test_cases.md
+++ b/docs/api/test_tools/test_cases.md
@@ -45,7 +45,8 @@ Unset the current agent context.
 def set_config(cls,
                dotted_path: str,
                value: Any,
-               type_: Optional[str] = None) -> Result
+               type_: Optional[str] = None,
+               aev: bool = False) -> Result
 ```
 
 Set a config.
@@ -57,6 +58,7 @@ Run from agent's directory.
 - `dotted_path`: str dotted path to config param.
 - `value`: a new value to set.
 - `type_`: the type
+- `aev`: use the environment variables
 
 **Returns**:
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ base_deps = [
 ]
 
 if os.name == "nt" or os.getenv("WIN_BUILD_WHEEL", None) == "1":
-    base_deps.append("pywin32>=300,<305")
+    base_deps.append("pywin32>=300,<304")
 
 here = os.path.abspath(os.path.dirname(__file__))
 about: Dict[str, str] = {}


### PR DESCRIPTION
## Proposed changes

This PR enables the usage of `--aev` flag on `aea config` command to support 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
