### PR TITLE
DO NOT MERGE added in failing when demonstrate list types the aea is unable to parse

### DIFF
--- a/tests/test_helpers/test_env_vars.py
+++ b/tests/test_helpers/test_env_vars.py
@@ -78,3 +78,12 @@ def test_convert_value_str_to_type():
     assert convert_value_str_to_type("none", "str") is None
     assert convert_value_str_to_type("null", "str") is None
     assert convert_value_str_to_type("None", "str") is None
+
+def test_convert_list_string_to_type():
+    """Test convert_string lists to list."""
+    assert convert_value_str_to_type("['a']", "list") == ['a']
+    assert convert_value_str_to_type('["a"]', "list") == ['a']
+    assert convert_value_str_to_type('[["a"]]', "list") == [['a']]
+
+
+

--- a/tests/test_helpers/test_env_vars.py
+++ b/tests/test_helpers/test_env_vars.py
@@ -79,11 +79,9 @@ def test_convert_value_str_to_type():
     assert convert_value_str_to_type("null", "str") is None
     assert convert_value_str_to_type("None", "str") is None
 
+
 def test_convert_list_string_to_type():
     """Test convert_string lists to list."""
-    assert convert_value_str_to_type("['a']", "list") == ['a']
-    assert convert_value_str_to_type('["a"]', "list") == ['a']
-    assert convert_value_str_to_type('[["a"]]', "list") == [['a']]
-
+    assert convert_value_str_to_type(str(['a']), "list") == ['a']
 
 


### PR DESCRIPTION
## Proposed changes

this pr adds in a test for non json dumped list types to apply environment variables.

```
value = "['a']", type_str = 'list'

    def convert_value_str_to_type(value: str, type_str: str) -> JSON_TYPES:
        """Convert value by type name to native python type."""
        try:
            type_ = FROM_STRING_TO_TYPE[type_str]
            if type_ == bool:
                return value not in FALSE_EQUIVALENTS
            if type_ is None or value in NULL_EQUIVALENTS:
                return None
            if type_ in (dict, list):
                return json.loads(value)
            return type_(value)
        except (ValueError, json.decoder.JSONDecodeError):  # pragma: no cover
>           raise ValueError(f"Cannot convert string `{value}` to type `{type_.__name__}`")  # type: ignore
E           ValueError: Cannot convert string `['a']` to type `list`

```

```
pytest tests/test_helpers/test_env_vars.py 
```

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

