### PR TITLE
Fix local initialisation of `IPFSTool/IPFSDaemon`

### DIFF
--- a/docs/api/plugins/aea_cli_ipfs/ipfs_utils.md
+++ b/docs/api/plugins/aea_cli_ipfs/ipfs_utils.md
@@ -32,6 +32,16 @@ def addr_to_url(addr: str) -> str
 
 Convert address to url.
 
+<a id="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.is_remote"></a>
+
+#### is`_`remote
+
+```python
+def is_remote(host: str) -> bool
+```
+
+Check is addr is remote or local.
+
 <a id="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.IPFSDaemon"></a>
 
 ## IPFSDaemon Objects
@@ -51,7 +61,7 @@ Set up the IPFS daemon.
 #### `__`init`__`
 
 ```python
-def __init__(node_url: str = "http://127.0.0.1:5001")
+def __init__(node_url: str = "http://127.0.0.1:5001", is_remote: bool = False)
 ```
 
 Initialise IPFS daemon.

--- a/docs/api/plugins/aea_cli_ipfs/ipfs_utils.md
+++ b/docs/api/plugins/aea_cli_ipfs/ipfs_utils.md
@@ -32,15 +32,15 @@ def addr_to_url(addr: str) -> str
 
 Convert address to url.
 
-<a id="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.is_remote"></a>
+<a id="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.is_remote_addr"></a>
 
-#### is`_`remote
+#### is`_`remote`_`addr
 
 ```python
-def is_remote(host: str) -> bool
+def is_remote_addr(host: str) -> bool
 ```
 
-Check is addr is remote or local.
+Check if addr is remote or local.
 
 <a id="plugins.aea-cli-ipfs.aea_cli_ipfs.ipfs_utils.IPFSDaemon"></a>
 

--- a/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
+++ b/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
@@ -90,7 +90,7 @@ def addr_to_url(addr: str) -> str:
 
 def is_remote_addr(host: str) -> bool:
     """Check is addr is remote or local."""
-    return host not in ("localhost", "127.0.0.1", "0.0.0.0")
+    return host not in ("localhost", "127.0.0.1", "0.0.0.0")  # nosec
 
 
 class IPFSDaemon:

--- a/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
+++ b/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
@@ -89,7 +89,7 @@ def addr_to_url(addr: str) -> str:
 
 
 def is_remote_addr(host: str) -> bool:
-    """Check is addr is remote or local."""
+    """Check if addr is remote or local."""
     return host not in ("localhost", "127.0.0.1", "0.0.0.0")  # nosec
 
 

--- a/plugins/aea-cli-ipfs/tests/test_utils.py
+++ b/plugins/aea-cli-ipfs/tests/test_utils.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2022 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Test ipfs utils."""
+
+from aea_cli_ipfs.ipfs_utils import IPFSTool
+
+from aea.cli.registry.settings import DEFAULT_IPFS_URL, DEFAULT_IPFS_URL_LOCAL
+
+
+def test_init_tool() -> None:
+    """Test tool initialization."""
+
+    tool = IPFSTool(DEFAULT_IPFS_URL)
+    assert tool.is_remote is True
+
+    tool = IPFSTool(DEFAULT_IPFS_URL_LOCAL)
+    assert tool.is_remote is False


### PR DESCRIPTION
## Proposed changes

This PR updates the IPFSDaemon to perform ipfs installation check only when initialised locally.

## Fix

https://github.com/valory-xyz/open-aea/pull/212#discussion_r914481029

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
