### PR TITLE
Add test to check package hash on signing protocol constant

### DIFF
--- a/aea/configurations/constants.py
+++ b/aea/configurations/constants.py
@@ -29,7 +29,7 @@ _ETHEREUM_IDENTIFIER = "ethereum"
 _COSMOS_IDENTIFIER = "cosmos"
 SIGNING_PROTOCOL = "open_aea/signing:latest"
 SIGNING_PROTOCOL_WITH_HASH = (
-    "open_aea/signing:1.0.0:QmTCQKD2iSjBUC3QCQRc7ZyNbnnrvoyw7EcQdJa7mQYLUW"
+    "open_aea/signing:1.0.0:QmX5gZL9j8y1z8HYkNJmMkcdTBH4ENiJBAFfYYuJgYcHSH"
 )
 DEFAULT_LEDGER = _ETHEREUM_IDENTIFIER
 PRIVATE_KEY_PATH_SCHEMA = "{}_private_key.txt"

--- a/tests/test_configurations/test_constants.py
+++ b/tests/test_configurations/test_constants.py
@@ -17,7 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Test if constants as valid."""
+"""Test if constants are valid."""
 
 from pathlib import Path
 

--- a/tests/test_configurations/test_constants.py
+++ b/tests/test_configurations/test_constants.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2022 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Test if constants as valid."""
+
+from pathlib import Path
+
+from aea.configurations.constants import SIGNING_PROTOCOL_WITH_HASH
+from aea.configurations.data_types import PublicId
+from aea.helpers.io import from_csv
+
+from tests.conftest import ROOT_DIR
+
+
+def test_signing_protocol_hash() -> None:
+    """Test signing protocol"""
+
+    public_id = PublicId.from_str(SIGNING_PROTOCOL_WITH_HASH)
+    hashes = from_csv(Path(ROOT_DIR, "packages", "hashes.csv"))
+    assert public_id.hash == hashes["open_aea/protocols/signing"]


### PR DESCRIPTION
## Proposed changes

This PR adds test to check if the signing protocol constant contains the latest hash or not

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
