### PR TITLE
Create property to determine if skill is abstract in context

### DIFF
--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -87,6 +87,13 @@ class SkillContext:
         self._logger: Optional[Logger] = None
 
     @property
+    def is_abstract_component(self) -> bool:
+        """Get if the skill is abstract."""
+        if self._skill is None:
+            raise ValueError("Skill not set yet.")  # pragma: nocover
+        return self._skill.configuration.is_abstract_component
+
+    @property
     def logger(self) -> Logger:
         """Get the logger."""
         if self._logger is None:

--- a/docs/api/skills/base.md
+++ b/docs/api/skills/base.md
@@ -30,6 +30,17 @@ Initialize a skill context.
 - `agent_context`: the agent context.
 - `skill`: the skill.
 
+<a id="aea.skills.base.SkillContext.is_abstract_component"></a>
+
+#### is`_`abstract`_`component
+
+```python
+@property
+def is_abstract_component() -> bool
+```
+
+Get if the skill is abstract.
+
 <a id="aea.skills.base.SkillContext.logger"></a>
 
 #### logger

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -216,6 +216,17 @@ class BaseTestSkillContext:
 class TestSkillContextDefault(BaseTestSkillContext):
     """Test skill context with default dm."""
 
+    @pytest.mark.parametrize("flag", (True, False))
+    def test_is_abstract(self, flag: bool):
+        """Test the `is_abstract` property."""
+        skill_context = SkillContext(
+            MagicMock(),
+            Skill(
+                SkillConfig("test_name", "test_author", is_abstract=flag), MagicMock()
+            ),
+        )
+        assert skill_context.is_abstract_component is flag
+
 
 class SkillContextTestCase(TestCase):
     """Test case for SkillContext class."""


### PR DESCRIPTION
## Proposed changes

Create property to determine if skill is abstract in context.
Requierement was mentioned in https://github.com/valory-xyz/open-autonomy/pull/1086#discussion_r923035167.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a