### PR TITLE
tests: ACN auto multiplex

### DIFF
--- a/aea/helpers/acn/uri.py
+++ b/aea/helpers/acn/uri.py
@@ -20,8 +20,11 @@
 
 """This module contains types and helpers for libp2p connections Uris."""
 
-from random import randint
+from itertools import count
 from typing import Optional
+
+
+ports = count(5000)
 
 
 class Uri:
@@ -45,15 +48,15 @@ class Uri:
             self._port = port
         else:
             self._host = "127.0.0.1"
-            self._port = randint(5000, 10000)  # nosec
+            self._port = next(ports)
 
     def __str__(self) -> str:
         """Get string representation."""
-        return "{}:{}".format(self._host, self._port)
+        return f"{self.host}:{self.port}"
 
     def __repr__(self) -> str:  # pragma: no cover
         """Get object representation."""
-        return self.__str__()
+        return str(self)
 
     @property
     def host(self) -> str:

--- a/tests/test_helpers/test_acn/test_uri.py
+++ b/tests/test_helpers/test_acn/test_uri.py
@@ -36,6 +36,6 @@ def test_uri2():
     """Test the uri."""
     Uri(host="127.0.0.1")
     uri = Uri(host="127.0.0.1", port=10000)
-    assert str(uri) == "127.0.0.1:9000"
+    assert str(uri) == "127.0.0.1:10000"
     assert uri.host == "127.0.0.1"
     assert uri.port == 10000

--- a/tests/test_helpers/test_acn/test_uri.py
+++ b/tests/test_helpers/test_acn/test_uri.py
@@ -30,3 +30,12 @@ def test_uri():
     assert uri.host == "localhost"
     assert uri.port == 9000
     Uri()
+
+
+def test_uri2():
+    """Test the uri."""
+    Uri(host="127.0.0.1")
+    uri = Uri(host="127.0.0.1", port=10000)
+    assert str(uri) == "127.0.0.1:9000"
+    assert uri.host == "127.0.0.1"
+    assert uri.port == 10000

--- a/tests/test_packages/test_connections/test_p2p_libp2p/base.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/base.py
@@ -338,9 +338,7 @@ class BaseP2PLibp2pTest:
         cls.cwd, cls.t = os.getcwd(), TEMP_LIBP2P_TEST_DIR
         if Path(cls.t).exists():
             cls.remove_temp_test_dir()
-        cls.tmp_dir = os.path.join(cls.t, "temp_dir")
-        cls.tmp_client_dir = os.path.join(cls.t, "temp_client_dir")
-        Path(cls.tmp_dir).mkdir(parents=True, exist_ok=True)
+        Path(cls.t).mkdir()
         os.chdir(cls.t)
 
     @classmethod
@@ -413,3 +411,24 @@ class BaseP2PLibp2pTest:
         attrs_are_identical = (getattr(sent, a) == getattr(echoed, a) for a in attrs)
         addresses_inverted = (getattr(sent, k) == getattr(echoed, v) for k, v in items)
         return all(attrs_are_identical) and all(addresses_inverted)
+
+    @classmethod
+    def _multiplex_it(cls, connection):
+        multiplexer = Multiplexer([connection], protocols=[MockDefaultMessageProtocol])
+        cls.multiplexers.append(multiplexer)
+        multiplexer.connect()
+        return connection
+
+    @classmethod
+    def make_connection(cls, **kwargs) -> P2PLibp2pConnection:
+        connection = cls._multiplex_it(_make_libp2p_connection(**kwargs))
+        cls.log_files.append(connection.node.log_file)
+        return connection
+
+    @classmethod
+    def make_client_connection(cls, **kwargs) -> P2PLibp2pClientConnection:
+        return cls._multiplex_it(_make_libp2p_client_connection(**kwargs))
+
+    @classmethod
+    def make_mailbox_connection(cls, **kwargs) -> P2PLibp2pMailboxConnection:
+        return cls._multiplex_it(_make_libp2p_mailbox_connection(**kwargs))

--- a/tests/test_packages/test_connections/test_p2p_libp2p/base.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/base.py
@@ -19,6 +19,7 @@
 
 """Constants, utility functions and base classes for ACN p2p_libp2p tests"""
 
+import asyncio
 import atexit
 import functools
 import inspect
@@ -62,9 +63,16 @@ from packages.valory.connections.p2p_libp2p_mailbox.connection import (
 )
 
 from tests.common.utils import wait_for_condition
-from tests.conftest import DEFAULT_HOST, DEFAULT_LEDGER, remove_test_directory
+from tests.conftest import (
+    CosmosCrypto,
+    DEFAULT_HOST,
+    DEFAULT_LEDGER,
+    EthereumCrypto,
+    remove_test_directory,
+)
 
 
+TIMEOUT = 20
 TEMP_LIBP2P_TEST_DIR = os.path.join(tempfile.gettempdir(), "tmp_libp2p_tests")
 ports = itertools.count(10234)
 
@@ -129,13 +137,13 @@ def make_cert_request(
     """Make cert request for ACN proof of representation (POR)"""
 
     cert_request = CertRequest(
-        public_key,
-        POR_DEFAULT_SERVICE_ID,
-        ledger_id,
-        LIBP2P_CERT_NOT_BEFORE,
-        LIBP2P_CERT_NOT_AFTER,
-        "{public_key}",
-        f"./{path_prefix}_cert.txt",
+        public_key=public_key,
+        identifier=POR_DEFAULT_SERVICE_ID,
+        ledger_id=ledger_id,
+        not_before=LIBP2P_CERT_NOT_BEFORE,
+        not_after=LIBP2P_CERT_NOT_AFTER,
+        message_format="{public_key}",
+        save_path=f"./{path_prefix}_cert.txt",
     )
 
     return cert_request
@@ -331,10 +339,13 @@ class BaseP2PLibp2pTest:
     multiplexers: List[Multiplexer] = []
     capture_log = True
 
+    libp2p_crypto = cosmos_crypto = make_crypto(CosmosCrypto.identifier)
+    default_crypto = ethereum_crypto = make_crypto(EthereumCrypto.identifier)
+    _cryptos = (None, cosmos_crypto, ethereum_crypto)
+
     @classmethod
     def setup_class(cls):
         """Set the test up"""
-
         atexit.register(cls.teardown_class)
         cls.cwd, cls.tmp = os.getcwd(), TEMP_LIBP2P_TEST_DIR
         if Path(cls.tmp).exists():
@@ -345,10 +356,8 @@ class BaseP2PLibp2pTest:
     @classmethod
     def teardown_class(cls):
         """Tear down the test"""
-
         logging.debug(f"Cleaning up {cls.__name__}")
-        cls.disconnect()
-        wait_for_condition(lambda: cls.all_disconnected, timeout=10)
+        cls._disconnect()
         cls.multiplexers.clear()
         cls.log_files.clear()
         os.chdir(cls.cwd)
@@ -357,18 +366,15 @@ class BaseP2PLibp2pTest:
         logging.debug(f"Teardown of {cls.__name__} completed")
 
     @classmethod
-    def disconnect(cls):
+    def _disconnect(cls):
         """Disconnect multiplexers and their connections"""
-
         for mux in cls.multiplexers:
-            for con in mux.connections:
-                con.disconnect()
             mux.disconnect()
+        wait_for_condition(lambda: cls.all_disconnected, timeout=TIMEOUT)
 
     @classmethod
     def remove_temp_test_dir(cls) -> None:
         """Attempt to remove the temporary directory used during tests"""
-
         success = remove_test_directory(cls.tmp)
         if not success:
             logging.debug(f"{cls.tmp} could NOT be deleted")
@@ -394,26 +400,26 @@ class BaseP2PLibp2pTest:
         return envelope
 
     @property
+    def _all_connections(self):
+        return [c for m in self.multiplexers for c in m.connections]
+
+    @property
     def all_connected(self) -> bool:
         """Check if all connection of all multiplexers are connected"""
-
-        return all(c.is_connected for m in self.multiplexers for c in m.connections)
+        return all(c.is_connected for c in self._all_connections)
 
     @property
     def all_disconnected(self) -> bool:
         """Check if all connection of all multiplexers are disconnected"""
-
-        return all(c.is_disconnected for m in self.multiplexers for c in m.connections)
+        return all(c.is_disconnected for c in self._all_connections)
 
     def sent_is_delivered_envelope(self, sent: Envelope, delivered: Envelope) -> bool:
         """Check if attributes on sent match those on delivered envelope"""
-
         attrs = ["to", "sender", "protocol_specification_id", "message_bytes"]
         return all(getattr(sent, attr) == getattr(delivered, attr) for attr in attrs)
 
     def sent_is_echoed_envelope(self, sent: Envelope, echoed: Envelope) -> bool:
         """Check if attributes on sent match those on echoed envelope"""
-
         attrs = ["protocol_specification_id", "message_bytes"]
         items = {"to": "sender", "sender": "to"}.items()
         attrs_are_identical = (getattr(sent, a) == getattr(echoed, a) for a in attrs)
@@ -426,6 +432,7 @@ class BaseP2PLibp2pTest:
         multiplexer = Multiplexer([connection], protocols=[MockDefaultMessageProtocol])
         cls.multiplexers.append(multiplexer)
         multiplexer.connect()
+        wait_for_condition(lambda: connection.is_connected is True, TIMEOUT)
         return connection
 
     @classmethod
@@ -444,3 +451,35 @@ class BaseP2PLibp2pTest:
     def make_mailbox_connection(cls, **kwargs) -> P2PLibp2pMailboxConnection:
         """Make ACN mailbox connection, auto multiplexer for teardown"""
         return cls._multiplex_it(_make_libp2p_mailbox_connection(**kwargs))
+
+    @property
+    def node_connections(self) -> List[P2PLibp2pConnection]:
+        """Connections"""
+        return [c for c in self._all_connections if isinstance(c, P2PLibp2pConnection)]
+
+    @property
+    def client_connections(self) -> List[P2PLibp2pClientConnection]:
+        """Client connections"""
+        return [c for c in self._all_connections if isinstance(c, P2PLibp2pClientConnection)]
+
+    @property
+    def mailbox_connections(self) -> List[P2PLibp2pMailboxConnection]:
+        """Mailbox connections"""
+        return [c for c in self._all_connections if isinstance(c, P2PLibp2pMailboxConnection)]
+
+    @property
+    def node_multiplexers(self) -> List[Multiplexer]:
+        """Connections"""
+        return [m for m in self.multiplexers if all(isinstance(c, P2PLibp2pConnection) for c in m.connections)]
+
+    @property
+    def client_multiplexers(self) -> List[Multiplexer]:
+        """Client connections"""
+        return [m for m in self.multiplexers if all(isinstance(c, P2PLibp2pClientConnection) for c in m.connections)]
+
+    @property
+    def mailbox_multiplexers(self) -> List[Multiplexer]:
+        """Mailbox connections"""
+        return [m for m in self.multiplexers if all(isinstance(c, P2PLibp2pMailboxConnection) for c in m.connections)]
+
+

--- a/tests/test_packages/test_connections/test_p2p_libp2p/base.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/base.py
@@ -414,6 +414,7 @@ class BaseP2PLibp2pTest:
 
     @classmethod
     def _multiplex_it(cls, connection):
+        """Create multiplexer, append it, connect it, return connection"""
         multiplexer = Multiplexer([connection], protocols=[MockDefaultMessageProtocol])
         cls.multiplexers.append(multiplexer)
         multiplexer.connect()
@@ -421,14 +422,17 @@ class BaseP2PLibp2pTest:
 
     @classmethod
     def make_connection(cls, **kwargs) -> P2PLibp2pConnection:
+        """Make ACN connection, auto multiplexer for teardown"""
         connection = cls._multiplex_it(_make_libp2p_connection(**kwargs))
         cls.log_files.append(connection.node.log_file)
         return connection
 
     @classmethod
     def make_client_connection(cls, **kwargs) -> P2PLibp2pClientConnection:
+        """Make ACN client connection, auto multiplexer for teardown"""
         return cls._multiplex_it(_make_libp2p_client_connection(**kwargs))
 
     @classmethod
     def make_mailbox_connection(cls, **kwargs) -> P2PLibp2pMailboxConnection:
+        """Make ACN mailbox connection, auto multiplexer for teardown"""
         return cls._multiplex_it(_make_libp2p_mailbox_connection(**kwargs))

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
@@ -29,7 +29,7 @@ import pytest
 
 from aea.mail.base import Empty
 
-from packages.valory.connections.p2p_libp2p.connection import NodeClient, Uri
+from packages.valory.connections.p2p_libp2p.connection import NodeClient
 
 from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     BaseP2PLibp2pTest,

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
@@ -31,13 +31,11 @@ from aea_ledger_fetchai import FetchAICrypto
 
 from aea.crypto.registries import make_crypto
 from aea.mail.base import Empty
-from aea.multiplexer import Multiplexer
 
 from packages.valory.connections.p2p_libp2p.connection import NodeClient, Uri
 
 from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     BaseP2PLibp2pTest,
-    MockDefaultMessageProtocol,
     _make_libp2p_connection,
     libp2p_log_on_failure_all,
 )

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
@@ -96,42 +96,25 @@ class TestP2PLibp2pConnectionEchoEnvelope(BaseP2PLibp2pTest):
 
         aea_ledger_fetchai = make_crypto(FetchAICrypto.identifier)
         aea_ledger_ethereum = make_crypto(EthereumCrypto.identifier)
-
-        cls.connection1 = _make_libp2p_connection(agent_key=aea_ledger_fetchai)
-        cls.multiplexer1 = Multiplexer(
-            [cls.connection1], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection1.node.log_file)
-        cls.multiplexer1.connect()
-        cls.multiplexers.append(cls.multiplexer1)
-
+        cls.connection1 = cls.make_connection(agent_key=aea_ledger_fetchai)
         genesis_peer = cls.connection1.node.multiaddrs[0]
-
-        cls.connection2 = _make_libp2p_connection(
-            entry_peers=[genesis_peer],
-            agent_key=aea_ledger_ethereum,
+        cls.connection2 = cls.make_connection(
+            entry_peers=[genesis_peer], agent_key=aea_ledger_ethereum
         )
-        cls.multiplexer2 = Multiplexer(
-            [cls.connection2], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection2.node.log_file)
-        cls.multiplexer2.connect()
-        cls.multiplexers.append(cls.multiplexer2)
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.connection1.is_connected is True
-        assert self.connection2.is_connected is True
+        assert self.all_multiplexer_connections_connected
 
     def test_envelope_routed(self):
         """Test envelope routed."""
 
         sender = self.connection1.address
         to = self.connection2.address
-
         envelope = self.enveloped_default_message(to=to, sender=sender)
-        self.multiplexer1.put(envelope)
-        delivered_envelope = self.multiplexer2.get(block=True, timeout=20)
+
+        self.multiplexers[0].put(envelope)
+        delivered_envelope = self.multiplexers[1].get(block=True, timeout=20)
 
         assert delivered_envelope is not None
         assert self.sent_is_delivered_envelope(envelope, delivered_envelope)
@@ -141,21 +124,20 @@ class TestP2PLibp2pConnectionEchoEnvelope(BaseP2PLibp2pTest):
 
         sender = self.connection1.address
         to = self.connection2.address
-
         envelope = self.enveloped_default_message(to=to, sender=sender)
 
-        self.multiplexer1.put(envelope)
-        delivered_envelope = self.multiplexer2.get(block=True, timeout=10)
-        assert delivered_envelope is not None
+        self.multiplexers[0].put(envelope)
+        delivered_envelope = self.multiplexers[1].get(block=True, timeout=10)
 
+        assert delivered_envelope is not None
         delivered_envelope.to = sender
         delivered_envelope.sender = to
 
-        self.multiplexer2.put(delivered_envelope)
-        echoed_envelope = self.multiplexer1.get(block=True, timeout=5)
+        self.multiplexers[1].put(delivered_envelope)
+        echoed_envelope = self.multiplexers[0].get(block=True, timeout=5)
 
         assert echoed_envelope is not None
-        self.sent_is_echoed_envelope(envelope, echoed_envelope)
+        assert self.sent_is_echoed_envelope(envelope, echoed_envelope)
 
 
 @libp2p_log_on_failure_all
@@ -167,22 +149,10 @@ class TestP2PLibp2pConnectionRouting(BaseP2PLibp2pTest):
         """Set the test up"""
         super().setup_class()
 
-        cls.connection_genesis = _make_libp2p_connection()
-        cls.multiplexer_genesis = Multiplexer(
-            [cls.connection_genesis], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection_genesis.node.log_file)
-        cls.multiplexer_genesis.connect()
-        cls.multiplexers.append(cls.multiplexer_genesis)
-
-        genesis_peer = cls.connection_genesis.node.multiaddrs[0]
-
+        connection_genesis = cls.make_connection()
+        genesis_peer = connection_genesis.node.multiaddrs[0]
         for _ in range(DEFAULT_NET_SIZE):
-            conn = _make_libp2p_connection(entry_peers=[genesis_peer])
-            mux = Multiplexer([conn], protocols=[MockDefaultMessageProtocol])
-            cls.log_files.append(conn.node.log_file)
-            mux.connect()
-            cls.multiplexers.append(mux)
+            cls.make_connection(entry_peers=[genesis_peer])
 
     def test_connection_is_established(self):
         """Test connection established."""
@@ -191,7 +161,7 @@ class TestP2PLibp2pConnectionRouting(BaseP2PLibp2pTest):
     def test_star_routing_connectivity(self):
         """Test star routing connectivity."""
 
-        addrs = [c.address for mux in self.multiplexers for c in mux.connections]
+        addrs = [c.address for m in self.multiplexers for c in m.connections]
         nodes = range(len(self.multiplexers))
         for u, v in permutations(nodes, 2):
             envelope = self.enveloped_default_message(to=addrs[v], sender=addrs[u])
@@ -210,31 +180,11 @@ class TestP2PLibp2pConnectionEchoEnvelopeRelayOneDHTNode(BaseP2PLibp2pTest):
         """Set the test up"""
         super().setup_class()
 
-        cls.relay = _make_libp2p_connection()
-        cls.multiplexer = Multiplexer([cls.relay])
-        cls.log_files.append(cls.relay.node.log_file)
-        cls.multiplexer.connect()
-        cls.multiplexers.append(cls.multiplexer)
+        relay = cls.make_connection()
+        relay_peer = relay.node.multiaddrs[0]
 
-        relay_peer = cls.relay.node.multiaddrs[0]
-
-        cls.connection1 = _make_libp2p_connection(
-            relay=False,
-            entry_peers=[relay_peer],
-        )
-        cls.multiplexer1 = Multiplexer(
-            [cls.connection1], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection1.node.log_file)
-        cls.multiplexer1.connect()
-        cls.multiplexers.append(cls.multiplexer1)
-        cls.connection2 = _make_libp2p_connection(entry_peers=[relay_peer])
-        cls.multiplexer2 = Multiplexer(
-            [cls.connection2], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection2.node.log_file)
-        cls.multiplexer2.connect()
-        cls.multiplexers.append(cls.multiplexer2)
+        cls.connection1 = cls.make_connection(relay=False, entry_peers=[relay_peer])
+        cls.connection2 = cls.make_connection(entry_peers=[relay_peer])
 
     def test_connection_is_established(self):
         """Test connection established."""
@@ -242,12 +192,13 @@ class TestP2PLibp2pConnectionEchoEnvelopeRelayOneDHTNode(BaseP2PLibp2pTest):
 
     def test_envelope_routed(self):
         """Test envelope routed."""
+
         sender = self.connection1.address
         to = self.connection2.address
-
         envelope = self.enveloped_default_message(to=to, sender=sender)
-        self.multiplexer1.put(envelope)
-        delivered_envelope = self.multiplexer2.get(block=True, timeout=20)
+
+        self.multiplexers[1].put(envelope)
+        delivered_envelope = self.multiplexers[2].get(block=True, timeout=20)
 
         assert delivered_envelope is not None
         assert self.sent_is_delivered_envelope(envelope, delivered_envelope)
@@ -257,17 +208,17 @@ class TestP2PLibp2pConnectionEchoEnvelopeRelayOneDHTNode(BaseP2PLibp2pTest):
 
         sender = self.connection1.address
         to = self.connection2.address
-
         envelope = self.enveloped_default_message(to=to, sender=sender)
-        self.multiplexer1.put(envelope)
-        delivered_envelope = self.multiplexer2.get(block=True, timeout=10)
-        assert delivered_envelope is not None
 
+        self.multiplexers[1].put(envelope)
+        delivered_envelope = self.multiplexers[2].get(block=True, timeout=10)
+
+        assert delivered_envelope is not None
         delivered_envelope.to = sender
         delivered_envelope.sender = to
 
-        self.multiplexer2.put(delivered_envelope)
-        echoed_envelope = self.multiplexer1.get(block=True, timeout=5)
+        self.multiplexers[2].put(delivered_envelope)
+        echoed_envelope = self.multiplexers[1].get(block=True, timeout=5)
 
         assert echoed_envelope is not None
         self.sent_is_echoed_envelope(envelope, echoed_envelope)
@@ -282,52 +233,23 @@ class TestP2PLibp2pConnectionRoutingRelayTwoDHTNodes(BaseP2PLibp2pTest):
         """Set the test up"""
         super().setup_class()
 
-        def make_relay(relay_peer):
-            conn = _make_libp2p_connection(
-                relay=False,
-                entry_peers=[relay_peer],
-            )
-            mux = Multiplexer([conn])
-            mux.connect()
-            cls.connections.append(conn)
-            cls.multiplexers.append(mux)
-            cls.log_files.append(conn.node.log_file)
-
-        cls.connection_relay_1 = _make_libp2p_connection()
-        cls.multiplexer_relay_1 = Multiplexer(
-            [cls.connection_relay_1], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection_relay_1.node.log_file)
-        cls.multiplexer_relay_1.connect()
-        cls.multiplexers.append(cls.multiplexer_relay_1)
-
-        relay_peer_1 = cls.connection_relay_1.node.multiaddrs[0]
-        cls.connection_relay_2 = _make_libp2p_connection(entry_peers=[relay_peer_1])
-        cls.multiplexer_relay_2 = Multiplexer(
-            [cls.connection_relay_2], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection_relay_2.node.log_file)
-        cls.multiplexer_relay_2.connect()
-        cls.multiplexers.append(cls.multiplexer_relay_2)
-
-        relay_peer_2 = cls.connection_relay_2.node.multiaddrs[0]
-        cls.connections = [cls.connection_relay_1, cls.connection_relay_2]
+        cls.connection1 = cls.make_connection()
+        relay_peer_1 = cls.connection1.node.multiaddrs[0]
+        cls.connection2 = cls.make_connection(entry_peers=[relay_peer_1])
+        relay_peer_2 = cls.connection2.node.multiaddrs[0]
 
         for _ in range(DEFAULT_NET_SIZE // 2 + 1):
-            make_relay(relay_peer_1)
-            make_relay(relay_peer_2)
+            cls.make_connection(entry_peers=[relay_peer_1])
+            cls.make_connection(entry_peers=[relay_peer_2])
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.connection_relay_1.is_connected is True
-        assert self.connection_relay_2.is_connected is True
-        for conn in self.connections:
-            assert conn.is_connected is True
+        assert self.all_multiplexer_connections_connected
 
     def test_star_routing_connectivity(self):
         """Test star routing connectivity."""
 
-        addrs = [conn.address for conn in self.connections]
+        addrs = [c.address for m in self.multiplexers for c in m.connections]
         nodes = range(len(self.multiplexers))
         for u, v in permutations(nodes, 2):
             envelope = self.enveloped_default_message(to=addrs[v], sender=addrs[u])
@@ -376,25 +298,11 @@ class BaseTestP2PLibp2p(BaseP2PLibp2pTest):
         aea_ledger_fetchai = make_crypto(FetchAICrypto.identifier)
         aea_ledger_ethereum = make_crypto(EthereumCrypto.identifier)
 
-        cls.connection1 = _make_libp2p_connection(agent_key=aea_ledger_fetchai)
-        cls.multiplexer1 = Multiplexer(
-            [cls.connection1], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection1.node.log_file)
-        cls.multiplexer1.connect()
-        cls.multiplexers.append(cls.multiplexer1)
-
+        cls.connection1 = cls.make_connection(agent_key=aea_ledger_fetchai)
         genesis_peer = cls.connection1.node.multiaddrs[0]
-        cls.connection2 = _make_libp2p_connection(
-            entry_peers=[genesis_peer],
-            agent_key=aea_ledger_ethereum,
+        cls.connection2 = cls.make_connection(
+            entry_peers=[genesis_peer], agent_key=aea_ledger_ethereum
         )
-        cls.multiplexer2 = Multiplexer(
-            [cls.connection2], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection2.node.log_file)
-        cls.multiplexer2.connect()
-        cls.multiplexers.append(cls.multiplexer2)
 
 
 @libp2p_log_on_failure_all
@@ -419,8 +327,8 @@ class TestP2PLibp2PSendEnvelope(BaseTestP2PLibp2p):
         ) as _mock_logger, mock.patch.object(
             self.connection2.node.pipe, "write", side_effect=Exception("some error")
         ):
-            self.multiplexer2.put(envelope)
-            delivered_envelope = self.multiplexer1.get(block=True, timeout=20)
+            self.multiplexers[1].put(envelope)
+            delivered_envelope = self.multiplexers[0].get(block=True, timeout=20)
             _mock_logger.assert_called_with(
                 "Failed to send after pipe reconnect. Exception: some error. Try recover connection to node and send again."
             )
@@ -446,8 +354,8 @@ class TestP2PLibp2PReceiveEnvelope(BaseTestP2PLibp2p):
         ) as _mock_logger, mock.patch.object(
             self.connection2.node.pipe, "read", side_effect=Exception("some error")
         ):
-            self.multiplexer1.put(envelope)
-            delivered_envelope = self.multiplexer2.get(block=True, timeout=20)
+            self.multiplexers[0].put(envelope)
+            delivered_envelope = self.multiplexers[1].get(block=True, timeout=20)
             expected = "Failed to read. Exception: some error. Try reconnect to node and read again."
             _mock_logger.assert_has_calls([call(expected)])
 
@@ -477,16 +385,16 @@ class TestLibp2pEnvelopeOrder(BaseTestP2PLibp2p):
 
         for envelope in sent_envelopes:
             envelope.message = envelope.message_bytes  # encode
-            self.multiplexer1.put(envelope)
+            self.multiplexers[0].put(envelope)
 
         received_envelopes = []
         for _ in range(self.NB_ENVELOPES):
-            envelope = self.multiplexer2.get(block=True, timeout=3)
+            envelope = self.multiplexers[1].get(block=True, timeout=3)
             received_envelopes.append(envelope)
 
         # test no new message is "created"
         with pytest.raises(Empty):
-            self.multiplexer2.get(block=True, timeout=1)
+            self.multiplexers[1].get(block=True, timeout=1)
 
         assert len(sent_envelopes) == len(received_envelopes)
         for expected, actual in zip(sent_envelopes, received_envelopes):

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
@@ -102,7 +102,7 @@ class TestP2PLibp2pConnectionEchoEnvelope(BaseP2PLibp2pTest):
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.all_multiplexer_connections_connected
+        assert self.all_connected
 
     def test_envelope_routed(self):
         """Test envelope routed."""
@@ -154,7 +154,7 @@ class TestP2PLibp2pConnectionRouting(BaseP2PLibp2pTest):
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.all_multiplexer_connections_connected
+        assert self.all_connected
 
     def test_star_routing_connectivity(self):
         """Test star routing connectivity."""
@@ -186,7 +186,7 @@ class TestP2PLibp2pConnectionEchoEnvelopeRelayOneDHTNode(BaseP2PLibp2pTest):
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.all_multiplexer_connections_connected
+        assert self.all_connected
 
     def test_envelope_routed(self):
         """Test envelope routed."""
@@ -242,7 +242,7 @@ class TestP2PLibp2pConnectionRoutingRelayTwoDHTNodes(BaseP2PLibp2pTest):
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.all_multiplexer_connections_connected
+        assert self.all_connected
 
     def test_star_routing_connectivity(self):
         """Test star routing connectivity."""
@@ -309,7 +309,7 @@ class TestP2PLibp2PSendEnvelope(BaseTestP2PLibp2p):
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.all_multiplexer_connections_connected
+        assert self.all_connected
 
     def test_envelope_routed(self):
         """Test envelope routed."""

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
@@ -91,7 +91,7 @@ class TestP2PLibp2pConnectionFailureSetupNewConnection(BaseP2PLibp2pTest):
         cls.identity = create_identity(crypto)
         cls.host = "localhost"
         cls.port = next(ports)
-        cls.key_file = os.path.join(cls.t, "keyfile")
+        cls.key_file = os.path.join(cls.tmp, "keyfile")
         crypto.dump(cls.key_file)
 
     def test_entry_peers_when_no_public_uri_provided(self):
@@ -104,11 +104,11 @@ class TestP2PLibp2pConnectionFailureSetupNewConnection(BaseP2PLibp2pTest):
             entry_peers=None,
             log_file=None,
             connection_id=P2PLibp2pConnection.connection_id,
-            build_directory=self.t,
+            build_directory=self.tmp,
         )
         with pytest.raises(ValueError, match="Couldn't find connection key"):
             P2PLibp2pConnection(
-                configuration=configuration, data_dir=self.t, identity=self.identity
+                configuration=configuration, data_dir=self.tmp, identity=self.identity
             )
 
     def test_local_uri_provided_when_public_uri_provided(self):
@@ -120,11 +120,11 @@ class TestP2PLibp2pConnectionFailureSetupNewConnection(BaseP2PLibp2pTest):
             entry_peers=None,
             log_file=None,
             connection_id=P2PLibp2pConnection.connection_id,
-            build_directory=self.t,
+            build_directory=self.tmp,
         )
         with pytest.raises(ValueError, match="Couldn't find connection key"):
             P2PLibp2pConnection(
-                configuration=configuration, data_dir=self.t, identity=self.identity
+                configuration=configuration, data_dir=self.tmp, identity=self.identity
             )
 
 

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
@@ -33,7 +33,6 @@ import pytest
 
 from aea.configurations.base import ConnectionConfig
 from aea.crypto.registries import make_crypto
-from aea.identity.base import Identity
 from aea.multiplexer import Multiplexer
 
 from packages.valory.connections.p2p_libp2p.connection import (
@@ -49,13 +48,10 @@ from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     BaseP2PLibp2pTest,
     DEFAULT_LEDGER,
     _make_libp2p_connection,
+    create_identity,
     ports,
 )
 
-
-check_node_built = (
-    f"{P2PLibp2pConnection.__module__}.{P2PLibp2pConnection.__name__}._check_node_built"
-)
 
 DEFAULT_NET_SIZE = 4
 
@@ -63,45 +59,21 @@ DEFAULT_NET_SIZE = 4
 class TestP2PLibp2pConnectionFailureGolangRun(BaseP2PLibp2pTest):
     """Test that golang run fails if wrong path or timeout"""
 
-    @classmethod
-    def setup_class(cls):
-        """Set the test up"""
-        super().setup_class()
-        cls.connection = _make_libp2p_connection()
-        cls.wrong_path = tempfile.mkdtemp()
-
     def test_wrong_path(self):
         """Test the wrong path."""
         log_file_desc = open("log", "a", 1)
-        with pytest.raises(Exception):
-            _golang_module_run(
-                self.wrong_path, LIBP2P_NODE_MODULE_NAME, [], log_file_desc
-            )
+        wrong_path = tempfile.mkdtemp()
+        with pytest.raises(FileNotFoundError, match="No such file or directory"):
+            _golang_module_run(wrong_path, LIBP2P_NODE_MODULE_NAME, [], log_file_desc)
 
     def test_timeout(self):
         """Test the timeout."""
-        self.connection.node._connection_timeout = 0
-        muxer = Multiplexer([self.connection])
-        with pytest.raises(Exception):
+
+        connection = _make_libp2p_connection()
+        connection.node._connection_timeout = 0
+        muxer = Multiplexer([connection])
+        with pytest.raises(Exception, match="Couldn't connect to libp2p process"):
             muxer.connect()
-        muxer.disconnect()
-
-
-class TestP2PLibp2pConnectionFailureNodeDisconnect(BaseP2PLibp2pTest):
-    """Test that connection handles node disconnecting properly"""
-
-    @classmethod
-    def setup_class(cls):
-        """Set the test up"""
-        super().setup_class()
-        cls.connection = _make_libp2p_connection()
-
-    def test_node_disconnect(self):
-        """Test node disconnect."""
-        muxer = Multiplexer([self.connection])
-        muxer.connect()
-        self.connection.node.proc.terminate()
-        self.connection.node.proc.wait()
         muxer.disconnect()
 
 
@@ -113,19 +85,18 @@ class TestP2PLibp2pConnectionFailureSetupNewConnection(BaseP2PLibp2pTest):
     @classmethod
     def setup_class(cls):
         """Set the test up"""
+
         super().setup_class()
         crypto = make_crypto(DEFAULT_LEDGER)
-        cls.identity = Identity(
-            "identity", address=crypto.address, public_key=crypto.public_key
-        )
+        cls.identity = create_identity(crypto)
         cls.host = "localhost"
         cls.port = next(ports)
-
         cls.key_file = os.path.join(cls.t, "keyfile")
         crypto.dump(cls.key_file)
 
     def test_entry_peers_when_no_public_uri_provided(self):
         """Test entry peers when no public uri provided."""
+
         configuration = ConnectionConfig(
             libp2p_key_file=None,
             local_uri=f"{self.host}:{self.port}",
@@ -135,13 +106,14 @@ class TestP2PLibp2pConnectionFailureSetupNewConnection(BaseP2PLibp2pTest):
             connection_id=P2PLibp2pConnection.connection_id,
             build_directory=self.t,
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Couldn't find connection key"):
             P2PLibp2pConnection(
                 configuration=configuration, data_dir=self.t, identity=self.identity
             )
 
     def test_local_uri_provided_when_public_uri_provided(self):
         """Test local uri provided when public uri provided."""
+
         configuration = ConnectionConfig(
             node_key_file=self.key_file,
             public_uri=f"{self.host}:{self.port}",
@@ -150,13 +122,13 @@ class TestP2PLibp2pConnectionFailureSetupNewConnection(BaseP2PLibp2pTest):
             connection_id=P2PLibp2pConnection.connection_id,
             build_directory=self.t,
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Couldn't find connection key"):
             P2PLibp2pConnection(
                 configuration=configuration, data_dir=self.t, identity=self.identity
             )
 
 
-def test_libp2pconnection_mixed_ip_address():
+def test_libp2p_connection_mixed_ip_address():
     """Test correct public uri ip and entry peers ips configuration."""
     assert _ip_all_private_or_all_public([]) is True
     assert _ip_all_private_or_all_public(["127.0.0.1", "127.0.0.1"]) is True
@@ -167,10 +139,10 @@ def test_libp2pconnection_mixed_ip_address():
     assert _ip_all_private_or_all_public(["fetch.ai", "acn.fetch.ai"]) is True
 
 
-def test_libp2pconnection_node_config_registration_delay():
+def test_libp2p_connection_node_config_registration_delay():
     """Test node registration delay configuration"""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be a float number in seconds"):
         _make_libp2p_connection(peer_registration_delay="must_be_float")
 
 
@@ -194,8 +166,8 @@ def test_build_dir_not_set():
 @pytest.mark.asyncio
 async def test_reconnect_on_write_failed():
     """Test node restart on write fail."""
-    with patch(check_node_built, return_value="./"):
-        con = _make_libp2p_connection()
+
+    con = _make_libp2p_connection()
     node = Libp2pNode(Mock(), Mock(), "tmp", "tmp")
     con.node = node
     node.pipe = Mock()
@@ -340,7 +312,8 @@ async def test_send_acn_confirm_failed():
 
 @pytest.mark.asyncio
 async def test_send_acn_confirm_timeout():
-    """Test nodeclient send fails on timeout."""
+    """Test node client send fails on timeout."""
+
     node = Libp2pNode(Mock(), Mock(), "tmp", "tmp")
     f = Future()
     f.set_result(None)
@@ -360,7 +333,8 @@ async def test_send_acn_confirm_timeout():
 
 @pytest.mark.asyncio
 async def test_acn_decode_error_on_read():
-    """Test nodeclient send fails on read."""
+    """Test ACN decode error on read."""
+
     node = Libp2pNode(Mock(), Mock(), "tmp", "tmp")
     f = Future()
     f.set_result(b"some_data")
@@ -382,7 +356,8 @@ async def test_acn_decode_error_on_read():
 
 @pytest.mark.asyncio
 async def test_write_acn_error():
-    """Test nodeclient write acn error."""
+    """Test write ACN error."""
+
     node = Libp2pNode(Mock(), Mock(), "tmp", "tmp")
     f = Future()
     f.set_result(b"some_data")

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
@@ -61,7 +61,7 @@ class TestP2PLibp2pConnectionFailureGolangRun(BaseP2PLibp2pTest):
         """Test the wrong path."""
         log_file_desc = open("log", "a", 1)
         wrong_path = tempfile.mkdtemp()
-        with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        with pytest.raises(FileNotFoundError):  # match differs based on OS
             _golang_module_run(wrong_path, LIBP2P_NODE_MODULE_NAME, [], log_file_desc)
 
     def test_timeout(self):

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
@@ -32,7 +32,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 from aea.configurations.base import ConnectionConfig
-from aea.crypto.registries import make_crypto
 from aea.multiplexer import Multiplexer
 
 from packages.valory.connections.p2p_libp2p.connection import (
@@ -46,7 +45,6 @@ from packages.valory.protocols.acn.message import AcnMessage
 
 from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     BaseP2PLibp2pTest,
-    DEFAULT_LEDGER,
     _make_libp2p_connection,
     create_identity,
     ports,
@@ -87,7 +85,7 @@ class TestP2PLibp2pConnectionFailureSetupNewConnection(BaseP2PLibp2pTest):
         """Set the test up"""
 
         super().setup_class()
-        crypto = make_crypto(DEFAULT_LEDGER)
+        crypto = cls.default_crypto
         cls.identity = create_identity(crypto)
         cls.host = "localhost"
         cls.port = next(ports)

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_fault_tolerance.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_fault_tolerance.py
@@ -22,7 +22,7 @@
 import pytest
 
 from aea.crypto.registries import make_crypto
-from aea.multiplexer import Multiplexer, Empty
+from aea.multiplexer import Empty, Multiplexer
 
 from packages.valory.connections.p2p_libp2p.check_dependencies import build_node
 
@@ -68,25 +68,26 @@ class BaseTestLibp2pRelay(BaseP2PLibp2pTest):
 class TestLibp2pConnectionRelayNodeRestart(BaseTestLibp2pRelay):
     """Test that connection will reliably forward envelopes after its relay node restarted"""
 
-    def setup(cls):
-        """Set the test up"""
+    def setup(self):
+        """Set up the individual test method"""
 
-        cls.genesis = cls.make_connection()
-        genesis_peer = cls.genesis.node.multiaddrs[0]
-        cls.relay = cls.make_connection(entry_peers=[genesis_peer])
-        relay_peer = cls.relay.node.multiaddrs[0]
-        cls.connection1 = cls.make_connection(relay=False, entry_peers=[relay_peer])
-        cls.connection2 = cls.make_connection(relay=False, entry_peers=[relay_peer])
+        self.genesis = self.make_connection()
+        genesis_peer = self.genesis.node.multiaddrs[0]
+        self.relay = self.make_connection(entry_peers=[genesis_peer])
+        relay_peer = self.relay.node.multiaddrs[0]
+        self.connection1 = self.make_connection(relay=False, entry_peers=[relay_peer])
+        self.connection2 = self.make_connection(relay=False, entry_peers=[relay_peer])
 
         # create references for disconnecting and reconnecting
-        cls.multiplexer_genesis = cls.multiplexers[0]
-        cls.multiplexer_relay = cls.multiplexers[1]
-        cls.multiplexer1 = cls.multiplexers[2]
-        cls.multiplexer2 = cls.multiplexers[3]
+        self.multiplexer_genesis = self.multiplexers[0]
+        self.multiplexer_relay = self.multiplexers[1]
+        self.multiplexer1 = self.multiplexers[2]
+        self.multiplexer2 = self.multiplexers[3]
 
-    def teardown(cls):
-        cls.disconnect()
-        cls.multiplexers.clear()
+    def teardown(self):
+        """Teardown"""
+        self.disconnect()
+        self.multiplexers.clear()
 
     def test_connection_is_established(self):
         """Test connection established."""
@@ -157,7 +158,9 @@ class TestLibp2pConnectionRelayNodeRestart(BaseTestLibp2pRelay):
         def attempt_sending():
             envelope = self.enveloped_default_message(to=to, sender=sender)
             self.multiplexer1.put(envelope)
-            delivered_envelope = self.multiplexer_genesis.get(block=True, timeout=TIMEOUT)
+            delivered_envelope = self.multiplexer_genesis.get(
+                block=True, timeout=TIMEOUT
+            )
             assert delivered_envelope is not None
             assert self.sent_is_delivered_envelope(envelope, delivered_envelope)
 

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_fault_tolerance.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_fault_tolerance.py
@@ -21,7 +21,6 @@
 
 import pytest
 
-from aea.crypto.registries import make_crypto
 from aea.multiplexer import Empty, Multiplexer
 
 from packages.valory.connections.p2p_libp2p.check_dependencies import build_node
@@ -79,7 +78,7 @@ class TestLibp2pConnectionRelayNodeRestart(BaseTestLibp2pRelay):
 
     def teardown(self):
         """Teardown"""
-        self.disconnect()
+        self._disconnect()
         self.multiplexers.clear()
 
     def test_connection_is_established(self):
@@ -187,7 +186,7 @@ class TestLibp2pConnectionAgentMobility(BaseTestLibp2pRelay):
         cls.connection1 = cls.make_connection(entry_peers=[genesis_peer])
         cls.connection2 = cls.make_connection(
             entry_peers=[genesis_peer],
-            agent_key=make_crypto("fetchai"),
+            agent_key=cls.default_crypto,
         )
 
         cls.multiplexer_genesis = cls.multiplexers[0]

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_fault_tolerance.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_fault_tolerance.py
@@ -43,7 +43,7 @@ class BaseTestLibp2pRelay(BaseP2PLibp2pTest):
     def setup_class(cls):
         """Set the test up"""
         super().setup_class()
-        build_node(cls.t)
+        build_node(cls.tmp)
 
     def change_state_and_wait(
         self,
@@ -51,14 +51,7 @@ class BaseTestLibp2pRelay(BaseP2PLibp2pTest):
         expected_is_connected: bool = False,
         timeout: int = TIMEOUT,
     ) -> None:
-        """
-        Change state of a multiplexer (either connect or disconnect) and wait.
-
-        :param multiplexer: the multiplexer to connect/disconnect.
-        :param expected_is_connected: whether it should be connected or disconnected.
-        :param timeout: the maximum number seconds to wait.
-        :return: None
-        """
+        """Change state of a multiplexer (either connect or disconnect) and wait."""
         wait_for_condition(
             lambda: multiplexer.is_connected == expected_is_connected, timeout=timeout
         )
@@ -91,7 +84,7 @@ class TestLibp2pConnectionRelayNodeRestart(BaseTestLibp2pRelay):
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.all_multiplexer_connections_connected
+        assert self.all_connected
 
     def test_envelope_routed_from_peer_after_relay_restart(self):
         """Test envelope routed from third peer after relay restart."""

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_integration.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_integration.py
@@ -25,14 +25,9 @@ import itertools
 import pytest
 
 from aea.helpers.acn.uri import Uri
-from aea.multiplexer import Multiplexer
 
 from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     BaseP2PLibp2pTest,
-    MockDefaultMessageProtocol,
-    _make_libp2p_client_connection,
-    _make_libp2p_connection,
-    _make_libp2p_mailbox_connection,
     libp2p_log_on_failure_all,
 )
 
@@ -46,92 +41,51 @@ class TestP2PLibp2pConnectionIntegrationTest(BaseP2PLibp2pTest):
     """Test mix of relay/delegate agents and client connections work together"""
 
     @classmethod
-    def _multiplex_it(cls, conn):
-        multiplexer = Multiplexer([conn], protocols=[MockDefaultMessageProtocol])
-        cls.multiplexers.append(multiplexer)
-        multiplexer.connect()
-
-    @classmethod
     def setup_class(cls):
         """Set the test up"""
         super().setup_class()
 
         # relays
-        main_relay = _make_libp2p_connection(relay=True)
-        cls.log_files.append(main_relay.node.log_file)
-        cls._multiplex_it(main_relay)
+        main_relay = cls.make_connection()
         main_relay_peer = main_relay.node.multiaddrs[0]
-
-        relay_2 = _make_libp2p_connection(entry_peers=[main_relay_peer], relay=True)
-        cls.log_files.append(relay_2.node.log_file)
-        cls._multiplex_it(relay_2)
+        relay_2 = cls.make_connection(entry_peers=[main_relay_peer])
         relay_peer_2 = relay_2.node.multiaddrs[0]
 
         # delegates
-        delegate_1 = _make_libp2p_connection(
-            entry_peers=[main_relay_peer],
-            relay=True,
-            delegate=True,
-            mailbox=True,
+        delegate_1 = cls.make_connection(
+            entry_peers=[main_relay_peer], delegate=True, mailbox=True
         )
-        cls.log_files.append(delegate_1.node.log_file)
-        cls._multiplex_it(delegate_1)
-
-        delegate_2 = _make_libp2p_connection(
-            entry_peers=[relay_peer_2],
-            relay=True,
-            delegate=True,
-            mailbox=True,
+        delegate_2 = cls.make_connection(
+            entry_peers=[relay_peer_2], delegate=True, mailbox=True
         )
-        cls.log_files.append(delegate_2.node.log_file)
-        cls._multiplex_it(delegate_2)
 
         # agents
-        agent_connection_1 = _make_libp2p_connection(
-            entry_peers=[main_relay_peer],
-            relay=False,
-            delegate=False,
-        )
-        cls.log_files.append(agent_connection_1.node.log_file)
-        cls._multiplex_it(agent_connection_1)
-
-        agent_connection_2 = _make_libp2p_connection(
-            entry_peers=[relay_peer_2],
-            relay=False,
-            delegate=False,
-        )
-        cls.log_files.append(agent_connection_2.node.log_file)
-        cls._multiplex_it(agent_connection_2)
+        cls.make_connection(entry_peers=[main_relay_peer], relay=False)
+        cls.make_connection(entry_peers=[relay_peer_2], relay=False)
 
         # clients
-        client_connection_1 = _make_libp2p_client_connection(
+        cls.make_client_connection(
             peer_public_key=delegate_1.node.pub,
             node_host=delegate_1.node.delegate_uri.host,
             node_port=delegate_1.node.delegate_uri.port,
         )
-        cls._multiplex_it(client_connection_1)
-
-        client_connection_2 = _make_libp2p_client_connection(
+        cls.make_client_connection(
             peer_public_key=delegate_2.node.pub,
             node_host=delegate_2.node.delegate_uri.host,
             node_port=delegate_2.node.delegate_uri.port,
         )
-        cls._multiplex_it(client_connection_2)
 
         # mailboxes
-        mailbox_connection_1 = _make_libp2p_mailbox_connection(
+        cls.make_mailbox_connection(
             peer_public_key=delegate_1.node.pub,
             node_host=Uri(delegate_1.node.mailbox_uri).host,
             node_port=Uri(delegate_1.node.mailbox_uri).port,
         )
-        cls._multiplex_it(mailbox_connection_1)
-
-        mailbox_connection_2 = _make_libp2p_mailbox_connection(
+        cls.make_mailbox_connection(
             peer_public_key=delegate_2.node.pub,
             node_host=Uri(delegate_2.node.mailbox_uri).host,
             node_port=Uri(delegate_2.node.mailbox_uri).port,
         )
-        cls._multiplex_it(mailbox_connection_2)
 
     def test_connection_is_established(self):
         """Test connection established."""

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_integration.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_integration.py
@@ -89,7 +89,7 @@ class TestP2PLibp2pConnectionIntegrationTest(BaseP2PLibp2pTest):
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.all_multiplexer_connections_connected
+        assert self.all_connected
 
     def test_send_and_receive(self):
         """Test envelope send/received by every pair of connection."""

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_public_dht.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_public_dht.py
@@ -26,17 +26,13 @@ import os
 
 import pytest
 
-from aea.helpers.base import CertRequest
 from aea.test_tools.test_cases import AEATestCaseMany
 
 from packages.valory.connections import p2p_libp2p, p2p_libp2p_client
 from packages.valory.connections.p2p_libp2p.connection import (
     PUBLIC_ID as P2P_CONNECTION_PUBLIC_ID,
 )
-from packages.valory.connections.p2p_libp2p.consts import (
-    LIBP2P_CERT_NOT_AFTER,
-    LIBP2P_CERT_NOT_BEFORE,
-)
+
 from packages.valory.connections.p2p_libp2p_client.connection import (
     PUBLIC_ID as P2P_CLIENT_CONNECTION_PUBLIC_ID,
 )
@@ -47,6 +43,7 @@ from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     LIBP2P_LEDGER,
     libp2p_log_on_failure_all,
     load_client_connection_yaml_config,
+    make_cert_request,
     ports,
 )
 
@@ -262,18 +259,7 @@ class TestLibp2pConnectionPublicDHTDelegateAEACli(AEATestCaseMany):
         # generate certificates for connection
         self.nested_set_config(
             p2p_libp2p_client_path + ".cert_requests",
-            [
-                CertRequest(
-                    identifier="acn",
-                    ledger_id=agent_ledger_id,
-                    not_before=LIBP2P_CERT_NOT_BEFORE,
-                    not_after=LIBP2P_CERT_NOT_AFTER,
-                    public_key=public_key,
-                    message_format="{public_key}",
-                    save_path=f"./cli_test_cert_{public_key}.txt",
-                )
-                for public_key in public_keys
-            ],
+            [make_cert_request(k, agent_ledger_id, f"./cli_test_{k}") for k in public_keys],
         )
         self.run_cli_command("issue-certificates", cwd=self._get_cwd())
 

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_public_dht.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_public_dht.py
@@ -32,7 +32,6 @@ from packages.valory.connections import p2p_libp2p, p2p_libp2p_client
 from packages.valory.connections.p2p_libp2p.connection import (
     PUBLIC_ID as P2P_CONNECTION_PUBLIC_ID,
 )
-
 from packages.valory.connections.p2p_libp2p_client.connection import (
     PUBLIC_ID as P2P_CLIENT_CONNECTION_PUBLIC_ID,
 )
@@ -259,7 +258,10 @@ class TestLibp2pConnectionPublicDHTDelegateAEACli(AEATestCaseMany):
         # generate certificates for connection
         self.nested_set_config(
             p2p_libp2p_client_path + ".cert_requests",
-            [make_cert_request(k, agent_ledger_id, f"./cli_test_{k}") for k in public_keys],
+            [
+                make_cert_request(k, agent_ledger_id, f"./cli_test_{k}")
+                for k in public_keys
+            ],
         )
         self.run_cli_command("issue-certificates", cwd=self._get_cwd())
 

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_public_dht.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_public_dht.py
@@ -97,19 +97,16 @@ class TestLibp2pConnectionPublicDHTRelay(BaseP2PLibp2pTest):
     @property
     def pairs_with_same_entry_peers(self):
         """Multiplexer pairs with different entry peers"""
-        for i in range(0, len(self.multiplexers), 2):
-            yield self.multiplexers[i : i + 2]
+        return itertools.zip_longest(*[iter(self.multiplexers)] * 2)
 
     @property
     def pairs_with_different_entry_peers(self):
         """Multiplexer pairs with different entry peers"""
-        # permutations of each first node of a pair that uses the same entry peer
-        nodes = (self.multiplexers[i] for i in range(0, len(self.multiplexers), 2))
-        return itertools.permutations(nodes, 2)
+        return itertools.permutations(self.multiplexers[::2], 2)
 
     def test_connectivity(self):
         """Test connectivity."""
-        assert self.all_multiplexer_connections_connected
+        assert self.all_connected
 
     def test_communication_direct(self):
         """Test direct communication through the same entry peer"""

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_public_dht.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_public_dht.py
@@ -80,15 +80,18 @@ class TestLibp2pConnectionPublicDHTRelay(BaseP2PLibp2pTest):
 
     maddrs = PUBLIC_DHT_MADDRS
 
-    @classmethod
-    def setup_class(cls):
-        """Set up test"""
-        super().setup_class()
+    def setup(self):
+        """Setup test"""
+        assert len(self.maddrs) > 1, "Test requires at least 2 public DHT node"
+        for maddr in self.maddrs:
+            for _ in range(2):  # make pairs
+                self.make_connection(relay=False, entry_peers=[maddr])
 
-        assert len(cls.maddrs) > 1, "Test requires at least 2 public DHT node"
-        for maddr in cls.maddrs:  # make pairs
-            for _ in range(2):
-                cls.make_connection(relay=False, entry_peers=[maddr])
+    def teardown(self):
+        """Teardown after test method"""
+        self._disconnect()
+        self.multiplexers.clear()
+        self.log_files.clear()
 
     @property
     def pairs_with_same_entry_peers(self):
@@ -133,16 +136,13 @@ class TestLibp2pConnectionPublicDHTDelegate(TestLibp2pConnectionPublicDHTRelay):
     uris = PUBLIC_DHT_DELEGATE_URIS
     public_keys = PUBLIC_DHT_PUBLIC_KEYS
 
-    @classmethod
-    def setup_class(cls):  # overwrite the setup_class, reuse the tests
+    def setup(self):  # overwrite the setup, reuse the rest
         """Set up test"""
-        BaseP2PLibp2pTest.setup_class()
-
-        assert len(cls.uris) == len(cls.public_keys)
-        assert len(cls.uris) > 1 and len(cls.public_keys) > 1
-        for uri, public_keys in zip(cls.uris, cls.public_keys):
+        assert len(self.uris) == len(self.public_keys)
+        assert len(self.uris) > 1 and len(self.public_keys) > 1
+        for uri, public_keys in zip(self.uris, self.public_keys):
             for _ in range(2):
-                cls.make_client_connection(uri=uri, peer_public_key=public_keys)
+                self.make_client_connection(uri=uri, peer_public_key=public_keys)
 
 
 @pytest.mark.integration

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_slow_queue.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_slow_queue.py
@@ -48,7 +48,7 @@ class TestSlowQueue(BaseP2PLibp2pTest):
 
     def test_connection_is_established(self):
         """Test connection established."""
-        assert self.all_multiplexer_connections_connected
+        assert self.all_connected
 
     @pytest.mark.asyncio
     async def test_slow_queue(self):

--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_aea_cli.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_aea_cli.py
@@ -19,17 +19,13 @@
 # ------------------------------------------------------------------------------
 
 """This test module contains AEA cli tests for Libp2p tcp client connection."""
+
 import json
 
-from aea.helpers.base import CertRequest
 from aea.multiplexer import Multiplexer
 from aea.test_tools.test_cases import AEATestCaseEmpty
 
 from packages.valory.connections import p2p_libp2p_client
-from packages.valory.connections.p2p_libp2p.consts import (
-    LIBP2P_CERT_NOT_AFTER,
-    LIBP2P_CERT_NOT_BEFORE,
-)
 from packages.valory.connections.p2p_libp2p_client.connection import PUBLIC_ID
 
 from tests.conftest import DEFAULT_LEDGER, LOCAL_HOST
@@ -37,10 +33,10 @@ from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     _make_libp2p_connection,
     libp2p_log_on_failure_all,
     ports,
+    make_cert_request,
 )
 
 
-p2p_libp2p_client_path = f"vendor.{p2p_libp2p_client.__name__.split('.', 1)[-1]}"
 DEFAULT_HOST = LOCAL_HOST.hostname
 DEFAULT_CLIENTS_PER_NODE = 4
 DEFAULT_LAUNCH_TIMEOUT = 10
@@ -48,23 +44,29 @@ DEFAULT_LAUNCH_TIMEOUT = 10
 
 @libp2p_log_on_failure_all
 class TestP2PLibp2pClientConnectionAEARunning(AEATestCaseEmpty):
-    """Test AEA with p2p_libp2p_client connection is correctly run"""
+    """Test AEA with client connection is correctly run"""
+
+    conn_path = f"vendor.{p2p_libp2p_client.__name__.split('.', 1)[-1]}"
+    public_id = str(PUBLIC_ID)
+    port = next(ports)
+    uri = f"{DEFAULT_HOST}:{port}"
+    kwargs = dict(
+        delegate_host=DEFAULT_HOST,
+        delegate_port=port,
+        delegate=True,
+    )
 
     @classmethod
     def setup_class(cls):
         """Set up the test class."""
         super().setup_class()
-
-        cls.delegate_port = next(ports)
-        cls.node_connection = _make_libp2p_connection(
-            delegate_host=DEFAULT_HOST,
-            delegate_port=cls.delegate_port,
-            delegate=True,
-        )
+        cls.node_connection = _make_libp2p_connection(**cls.kwargs)
         cls.node_multiplexer = Multiplexer([cls.node_connection])
         cls.log_files = [cls.node_connection.node.log_file]
-
         cls.node_multiplexer.connect()
+        node = {"uri": cls.uri, "public_key": cls.node_connection.node.pub}
+        cls.nodes = {"nodes": [node]}
+        cls.expected = (f"Successfully connected to libp2p node {cls.uri}", )
 
     def test_node(self):
         """Test the node is connected."""
@@ -77,53 +79,23 @@ class TestP2PLibp2pClientConnectionAEARunning(AEATestCaseEmpty):
         self.add_private_key(ledger_id, f"{ledger_id}_private_key.txt")
         self.set_config("agent.default_ledger", ledger_id)
         self.set_config("agent.required_ledgers", json.dumps([ledger_id]), "list")
-        self.add_item("connection", str(PUBLIC_ID))
-        conn_path = p2p_libp2p_client_path
-        self.nested_set_config(
-            conn_path + ".config",
-            {
-                "nodes": [
-                    {
-                        "uri": "{}:{}".format(DEFAULT_HOST, self.delegate_port),
-                        "public_key": self.node_connection.node.pub,
-                    }
-                ]
-            },
-        )
+        self.add_item("connection", self.public_id)
+        self.nested_set_config(self.conn_path + ".config", self.nodes)
 
         # generate certificates for connection
         self.nested_set_config(
-            conn_path + ".cert_requests",
-            [
-                CertRequest(
-                    identifier="acn",
-                    ledger_id=ledger_id,
-                    not_before=LIBP2P_CERT_NOT_BEFORE,
-                    not_after=LIBP2P_CERT_NOT_AFTER,
-                    public_key=self.node_connection.node.pub,
-                    message_format="{public_key}",
-                    save_path="./cli_test_cert.txt",
-                )
-            ],
+            self.conn_path + ".cert_requests",
+            [make_cert_request(self.node_connection.node.pub, ledger_id, f"./cli_test")]
         )
         self.run_cli_command("issue-certificates", cwd=self._get_cwd())
 
         process = self.run_agent()
         is_running = self.is_running(process, timeout=DEFAULT_LAUNCH_TIMEOUT)
         assert is_running, "AEA not running within timeout!"
-
-        check_strings = "Successfully connected to libp2p node {}:{}".format(
-            DEFAULT_HOST, self.delegate_port
-        )
-        missing_strings = self.missing_from_output(process, check_strings)
-        assert (
-            missing_strings == []
-        ), "Strings {} didn't appear in agent output.".format(missing_strings)
-
+        missing_strings = self.missing_from_output(process, self.expected)
+        assert not missing_strings
         self.terminate_agents(process)
-        assert self.is_successfully_terminated(
-            process
-        ), "AEA wasn't successfully terminated."
+        assert self.is_successfully_terminated(process)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_aea_cli.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_aea_cli.py
@@ -32,8 +32,8 @@ from tests.conftest import DEFAULT_LEDGER, LOCAL_HOST
 from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     _make_libp2p_connection,
     libp2p_log_on_failure_all,
-    ports,
     make_cert_request,
+    ports,
 )
 
 
@@ -66,7 +66,7 @@ class TestP2PLibp2pClientConnectionAEARunning(AEATestCaseEmpty):
         cls.node_multiplexer.connect()
         node = {"uri": cls.uri, "public_key": cls.node_connection.node.pub}
         cls.nodes = {"nodes": [node]}
-        cls.expected = (f"Successfully connected to libp2p node {cls.uri}", )
+        cls.expected = (f"Successfully connected to libp2p node {cls.uri}",)
 
     def test_node(self):
         """Test the node is connected."""
@@ -85,7 +85,11 @@ class TestP2PLibp2pClientConnectionAEARunning(AEATestCaseEmpty):
         # generate certificates for connection
         self.nested_set_config(
             self.conn_path + ".cert_requests",
-            [make_cert_request(self.node_connection.node.pub, ledger_id, f"./cli_test")]
+            [
+                make_cert_request(
+                    self.node_connection.node.pub, ledger_id, f"./cli_test"
+                )
+            ],
         )
         self.run_cli_command("issue-certificates", cwd=self._get_cwd())
 

--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
@@ -20,77 +20,65 @@
 
 """This test module contains tests for Libp2p tcp client connection."""
 
-import asyncio
 import time
-from itertools import permutations
 from unittest import mock
-from unittest.mock import Mock, call
+from unittest.mock import call
 
 import pytest
 
-from aea.mail.base import Empty, Envelope
-from aea.multiplexer import Multiplexer
-
-from packages.fetchai.protocols.default.message import DefaultMessage
-from packages.fetchai.protocols.default.serialization import DefaultSerializer
-from packages.valory.connections.p2p_libp2p_client.connection import NodeClient, Uri
+from aea.mail.base import Empty
 
 from tests.common.mocks import RegexComparator
-from tests.common.utils import wait_for_condition
 from tests.conftest import DEFAULT_LEDGER
 from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     BaseP2PLibp2pTest,
     LIBP2P_LEDGER,
+    TIMEOUT,
     _make_libp2p_client_connection,
     _make_libp2p_connection,
     libp2p_log_on_failure_all,
     ports,
 )
+from tests.test_packages.test_connections.test_p2p_libp2p.test_communication import (
+    TestP2PLibp2pConnectionRouting,
+)
 
 
 DEFAULT_CLIENTS_PER_NODE = 1
 
-MockDefaultMessageProtocol = Mock()
-MockDefaultMessageProtocol.protocol_id = DefaultMessage.protocol_id
-MockDefaultMessageProtocol.protocol_specification_id = (
-    DefaultMessage.protocol_specification_id
-)
-
 
 @pytest.mark.asyncio
+@libp2p_log_on_failure_all
 class TestLibp2pClientConnectionConnectDisconnect(BaseP2PLibp2pTest):
     """Test that connection is established and torn down correctly"""
 
-    @classmethod
-    def setup_class(cls):
-        """Set the test up"""
-        super().setup_class()
-
-        cls.delegate_port = next(ports)
-        cls.connection_node = _make_libp2p_connection(
-            delegate=True, delegate_port=cls.delegate_port
-        )
-        cls.connection = _make_libp2p_client_connection(
-            peer_public_key=cls.connection_node.node.pub,
-            node_port=cls.delegate_port,
-        )
-
     @pytest.mark.asyncio
-    async def test_libp2pclientconnection_connect_disconnect(self):
+    async def test_libp2p_client_connection_connect_disconnect(self):
         """Test connnect then disconnect."""
-        assert self.connection.is_connected is False
+
+        delegate_port = next(ports)
+        connection_node = _make_libp2p_connection(
+            delegate=True, delegate_port=delegate_port
+        )
+        connection = _make_libp2p_client_connection(
+            peer_public_key=connection_node.node.pub,
+            node_port=delegate_port,
+        )
+
+        assert connection.is_connected is False
         try:
-            await self.connection_node.connect()
-            await self.connection.connect()
-            assert self.connection.is_connected is True
-            await self.connection.disconnect()
-            assert self.connection.is_connected is False
+            await connection_node.connect()
+            await connection.connect()
+            assert connection.is_connected is True
+            await connection.disconnect()
+            assert connection.is_connected is False
         except Exception:
             raise
         finally:
-            await self.connection_node.disconnect()
+            await connection_node.disconnect()
 
 
+@pytest.mark.asyncio
 @libp2p_log_on_failure_all
 class TestLibp2pClientConnectionEchoEnvelope(BaseP2PLibp2pTest):
     """Test that connection will route envelope to destination through the same libp2p node"""
@@ -100,164 +88,73 @@ class TestLibp2pClientConnectionEchoEnvelope(BaseP2PLibp2pTest):
         """Set the test up"""
         super().setup_class()
 
-        cls.delegate_port = next(ports)
-
-        cls.connection_node = _make_libp2p_connection(
+        delegate_port = next(ports)
+        cls.connection_node = cls.make_connection(
             delegate=True,
-            delegate_port=cls.delegate_port,
+            delegate_port=delegate_port,
         )
-        cls.multiplexer_node = Multiplexer(
-            [cls.connection_node], protocols=[MockDefaultMessageProtocol]
+
+        cls.connection_client_1 = cls.make_client_connection(
+            peer_public_key=cls.connection_node.node.pub,
+            ledger_api_id=cls.cosmos_crypto.identifier,
+            node_port=delegate_port,
         )
-        cls.log_files.append(cls.connection_node.node.log_file)
-        cls.multiplexer_node.connect()
-
-        try:
-            cls.connection_client_1 = _make_libp2p_client_connection(
-                peer_public_key=cls.connection_node.node.pub,
-                ledger_api_id=LIBP2P_LEDGER,
-                node_port=cls.delegate_port,
-            )
-            cls.multiplexer_client_1 = Multiplexer(
-                [cls.connection_client_1], protocols=[MockDefaultMessageProtocol]
-            )
-            cls.multiplexer_client_1.connect()
-
-            cls.connection_client_2 = _make_libp2p_client_connection(
-                peer_public_key=cls.connection_node.node.pub,
-                ledger_api_id=DEFAULT_LEDGER,
-                node_port=cls.delegate_port,
-            )
-            cls.multiplexer_client_2 = Multiplexer(
-                [cls.connection_client_2], protocols=[MockDefaultMessageProtocol]
-            )
-            cls.multiplexer_client_2.connect()
-
-            wait_for_condition(lambda: cls.connection_client_1.is_connected is True, 10)
-            wait_for_condition(lambda: cls.connection_client_2.is_connected is True, 10)
-        except Exception:
-            cls.multiplexer_node.disconnect()
-            raise
+        cls.connection_client_2 = cls.make_client_connection(
+            peer_public_key=cls.connection_node.node.pub,
+            ledger_api_id=cls.ethereum_crypto.identifier,
+            node_port=delegate_port,
+        )
 
     def test_connection_is_established(self):
         """Test connection is established."""
-        assert self.connection_client_1.is_connected is True
-        assert self.connection_client_2.is_connected is True
+        assert self.all_connected
 
     def test_envelope_routed(self):
         """Test the envelope is routed."""
-        addr_1 = self.connection_client_1.address
-        addr_2 = self.connection_client_2.address
 
-        msg = DefaultMessage(
-            dialogue_reference=("", ""),
-            message_id=1,
-            target=0,
-            performative=DefaultMessage.Performative.BYTES,
-            content=b"hello",
-        )
-        envelope = Envelope(
-            to=addr_2,
-            sender=addr_1,
-            protocol_specification_id=DefaultMessage.protocol_specification_id,
-            message=DefaultSerializer().encode(msg),
-        )
+        sender = self.connection_client_1.address
+        to = self.connection_client_2.address
+        envelope = self.enveloped_default_message(to=to, sender=sender)
 
-        self.multiplexer_client_1.put(envelope)
-        delivered_envelope = self.multiplexer_client_2.get(block=True, timeout=20)
-
-        assert delivered_envelope is not None
-        assert delivered_envelope.to == envelope.to
-        assert delivered_envelope.sender == envelope.sender
-        assert (
-            delivered_envelope.protocol_specification_id
-            == envelope.protocol_specification_id
-        )
-        assert delivered_envelope.message == envelope.message
+        self.multiplexers[1].put(envelope)
+        delivered_envelope = self.multiplexers[2].get(block=True, timeout=TIMEOUT)
+        assert self.sent_is_delivered_envelope(envelope, delivered_envelope)
 
     def test_envelope_echoed_back(self):
         """Test the envelope is echoed back."""
-        addr_1 = self.connection_client_1.address
-        addr_2 = self.connection_client_2.address
 
-        msg = DefaultMessage(
-            dialogue_reference=("", ""),
-            message_id=1,
-            target=0,
-            performative=DefaultMessage.Performative.BYTES,
-            content=b"hello",
-        )
-        original_envelope = Envelope(
-            to=addr_2,
-            sender=addr_1,
-            protocol_specification_id=DefaultMessage.protocol_specification_id,
-            message=DefaultSerializer().encode(msg),
-        )
+        sender = self.connection_client_1.address
+        to = self.connection_client_2.address
+        envelope = self.enveloped_default_message(to=to, sender=sender)
 
-        self.multiplexer_client_1.put(original_envelope)
-        delivered_envelope = self.multiplexer_client_2.get(block=True, timeout=10)
+        self.multiplexers[1].put(envelope)
+        delivered_envelope = self.multiplexers[2].get(block=True, timeout=TIMEOUT)
         assert delivered_envelope is not None
 
-        delivered_envelope.to = addr_1
-        delivered_envelope.sender = addr_2
+        delivered_envelope.to = sender
+        delivered_envelope.sender = to
 
-        self.multiplexer_client_2.put(delivered_envelope)
-        echoed_envelope = self.multiplexer_client_1.get(block=True, timeout=5)
-
-        assert echoed_envelope is not None
-        assert echoed_envelope.to == original_envelope.sender
-        assert delivered_envelope.sender == original_envelope.to
-        assert (
-            delivered_envelope.protocol_specification_id
-            == original_envelope.protocol_specification_id
-        )
-        assert delivered_envelope.message == original_envelope.message
+        self.multiplexers[2].put(delivered_envelope)
+        echoed_envelope = self.multiplexers[1].get(block=True, timeout=TIMEOUT)
+        assert self.sent_is_echoed_envelope(envelope, echoed_envelope)
 
     def test_envelope_echoed_back_node_agent(self):
         """Test the envelope is echoed back."""
-        addr_1 = self.connection_client_1.address
-        addr_n = self.connection_node.address
 
-        msg = DefaultMessage(
-            dialogue_reference=("", ""),
-            message_id=1,
-            target=0,
-            performative=DefaultMessage.Performative.BYTES,
-            content=b"hello",
-        )
-        original_envelope = Envelope(
-            to=addr_n,
-            sender=addr_1,
-            protocol_specification_id=DefaultMessage.protocol_specification_id,
-            message=DefaultSerializer().encode(msg),
-        )
+        sender = self.connection_client_1.address
+        to = self.connection_node.address
+        envelope = self.enveloped_default_message(to=to, sender=sender)
 
-        self.multiplexer_client_1.put(original_envelope)
-        delivered_envelope = self.multiplexer_node.get(block=True, timeout=10)
+        self.multiplexers[1].put(envelope)
+        delivered_envelope = self.multiplexers[0].get(block=True, timeout=TIMEOUT)
         assert delivered_envelope is not None
 
-        delivered_envelope.to = addr_1
-        delivered_envelope.sender = addr_n
+        delivered_envelope.to = sender
+        delivered_envelope.sender = to
 
-        self.multiplexer_node.put(delivered_envelope)
-        echoed_envelope = self.multiplexer_client_1.get(block=True, timeout=5)
-
-        assert echoed_envelope is not None
-        assert echoed_envelope.to == original_envelope.sender
-        assert delivered_envelope.sender == original_envelope.to
-        assert (
-            delivered_envelope.protocol_specification_id
-            == original_envelope.protocol_specification_id
-        )
-        assert delivered_envelope.message == original_envelope.message
-
-    @classmethod
-    def teardown_class(cls):
-        """Tear down the test"""
-        cls.multiplexer_client_1.disconnect()
-        cls.multiplexer_client_2.disconnect()
-        cls.multiplexer_node.disconnect()
-        super().teardown_class()
+        self.multiplexers[0].put(delivered_envelope)
+        echoed_envelope = self.multiplexers[1].get(block=True, timeout=TIMEOUT)
+        assert self.sent_is_echoed_envelope(envelope, echoed_envelope)
 
 
 @libp2p_log_on_failure_all
@@ -271,290 +168,108 @@ class TestLibp2pClientConnectionEchoEnvelopeTwoDHTNode(BaseP2PLibp2pTest):
 
         cls.ports = next(ports), next(ports)
 
-        cls.connection_node_1 = _make_libp2p_connection(
+        cls.connection_node_1 = cls.make_connection(
             delegate_port=cls.ports[0],
             delegate=True,
         )
-        cls.multiplexer_node_1 = Multiplexer(
-            [cls.connection_node_1], protocols=[MockDefaultMessageProtocol]
-        )
-        cls.log_files.append(cls.connection_node_1.node.log_file)
-        cls.multiplexer_node_1.connect()
-        cls.multiplexers.append(cls.multiplexer_node_1)
-
         genesis_peer = cls.connection_node_1.node.multiaddrs[0]
+        cls.connection_node_2 = cls.make_connection(
+            delegate_port=cls.ports[1],
+            entry_peers=[genesis_peer],
+            delegate=True,
+        )
 
-        try:
-            cls.connection_node_2 = _make_libp2p_connection(
-                delegate_port=cls.ports[1],
-                entry_peers=[genesis_peer],
-                delegate=True,
-            )
-            cls.multiplexer_node_2 = Multiplexer(
-                [cls.connection_node_2], protocols=[MockDefaultMessageProtocol]
-            )
-            cls.log_files.append(cls.connection_node_2.node.log_file)
-            cls.multiplexer_node_2.connect()
-            cls.multiplexers.append(cls.multiplexer_node_2)
-
-            cls.connection_client_1 = _make_libp2p_client_connection(
-                peer_public_key=cls.connection_node_1.node.pub,
-                node_port=cls.ports[0],
-            )
-            cls.multiplexer_client_1 = Multiplexer(
-                [cls.connection_client_1], protocols=[MockDefaultMessageProtocol]
-            )
-            cls.multiplexer_client_1.connect()
-            cls.multiplexers.append(cls.multiplexer_client_1)
-
-            cls.connection_client_2 = _make_libp2p_client_connection(
-                peer_public_key=cls.connection_node_2.node.pub,
-                node_port=cls.ports[1],
-            )
-            cls.multiplexer_client_2 = Multiplexer(
-                [cls.connection_client_2], protocols=[MockDefaultMessageProtocol]
-            )
-            cls.multiplexer_client_2.connect()
-            cls.multiplexers.append(cls.multiplexer_client_2)
-
-            wait_for_condition(lambda: cls.connection_node_1.is_connected is True, 10)
-            wait_for_condition(lambda: cls.connection_node_2.is_connected is True, 10)
-            wait_for_condition(lambda: cls.connection_client_1.is_connected is True, 10)
-            wait_for_condition(lambda: cls.connection_client_2.is_connected is True, 10)
-
-        except Exception:
-            cls.teardown_class()
-            raise
+        cls.connection_client_1 = cls.make_client_connection(
+            peer_public_key=cls.connection_node_1.node.pub,
+            node_port=cls.ports[0],
+        )
+        cls.connection_client_2 = cls.make_client_connection(
+            peer_public_key=cls.connection_node_2.node.pub,
+            node_port=cls.ports[1],
+        )
 
     def test_connection_is_established(self):
         """Test the connection is established."""
-        assert self.connection_node_1.is_connected is True
-        assert self.connection_node_2.is_connected is True
-        assert self.connection_client_1.is_connected is True
-        assert self.connection_client_2.is_connected is True
+        assert self.all_connected
 
     def test_envelope_routed(self):
         """Test the envelope is routed."""
-        addr_1 = self.connection_client_1.address
-        addr_2 = self.connection_client_2.address
 
-        msg = DefaultMessage(
-            dialogue_reference=("", ""),
-            message_id=1,
-            target=0,
-            performative=DefaultMessage.Performative.BYTES,
-            content=b"hello",
-        )
-        envelope = Envelope(
-            to=addr_2,
-            sender=addr_1,
-            protocol_specification_id=DefaultMessage.protocol_specification_id,
-            message=DefaultSerializer().encode(msg),
-        )
+        sender = self.connection_client_1.address
+        to = self.connection_client_2.address
 
-        self.multiplexer_client_1.put(envelope)
-        delivered_envelope = self.multiplexer_client_2.get(block=True, timeout=20)
+        envelope = self.enveloped_default_message(to=to, sender=sender)
+        self.multiplexers[2].put(envelope)
+        delivered_envelope = self.multiplexers[3].get(block=True, timeout=20)
 
-        assert delivered_envelope is not None
-        assert delivered_envelope.to == envelope.to
-        assert delivered_envelope.sender == envelope.sender
-        assert (
-            delivered_envelope.protocol_specification_id
-            == envelope.protocol_specification_id
-        )
-        assert delivered_envelope.message == envelope.message
+        assert self.sent_is_delivered_envelope(envelope, delivered_envelope)
 
     def test_envelope_echoed_back(self):
         """Test the envelope is echoed back."""
-        addr_1 = self.connection_client_1.address
-        addr_2 = self.connection_client_2.address
 
-        msg = DefaultMessage(
-            dialogue_reference=("", ""),
-            message_id=1,
-            target=0,
-            performative=DefaultMessage.Performative.BYTES,
-            content=b"hello",
-        )
-        original_envelope = Envelope(
-            to=addr_2,
-            sender=addr_1,
-            protocol_specification_id=DefaultMessage.protocol_specification_id,
-            message=DefaultSerializer().encode(msg),
-        )
+        sender = self.connection_client_1.address
+        to = self.connection_client_2.address
+        envelope = self.enveloped_default_message(to=to, sender=sender)
 
-        self.multiplexer_client_1.put(original_envelope)
-        delivered_envelope = self.multiplexer_client_2.get(block=True, timeout=10)
+        self.multiplexers[2].put(envelope)
+        delivered_envelope = self.multiplexers[3].get(block=True, timeout=10)
         assert delivered_envelope is not None
 
-        delivered_envelope.to = addr_1
-        delivered_envelope.sender = addr_2
+        delivered_envelope.to = sender
+        delivered_envelope.sender = to
 
-        self.multiplexer_client_2.put(delivered_envelope)
-        echoed_envelope = self.multiplexer_client_1.get(block=True, timeout=5)
-
-        assert echoed_envelope is not None
-        assert echoed_envelope.to == original_envelope.sender
-        assert delivered_envelope.sender == original_envelope.to
-        assert (
-            delivered_envelope.protocol_specification_id
-            == original_envelope.protocol_specification_id
-        )
-        assert delivered_envelope.message == original_envelope.message
+        self.multiplexers[3].put(delivered_envelope)
+        echoed_envelope = self.multiplexers[2].get(block=True, timeout=5)
+        assert self.sent_is_echoed_envelope(envelope, echoed_envelope)
 
     def test_envelope_echoed_back_node_agent(self):
         """Test the envelope is echoed back node agent."""
-        addr_1 = self.connection_client_1.address
-        addr_n = self.connection_node_2.address
 
-        msg = DefaultMessage(
-            dialogue_reference=("", ""),
-            message_id=1,
-            target=0,
-            performative=DefaultMessage.Performative.BYTES,
-            content=b"hello",
-        )
-        original_envelope = Envelope(
-            to=addr_n,
-            sender=addr_1,
-            protocol_specification_id=DefaultMessage.protocol_specification_id,
-            message=DefaultSerializer().encode(msg),
-        )
+        sender = self.connection_client_1.address
+        to = self.connection_node_2.address
+        envelope = self.enveloped_default_message(to=to, sender=sender)
 
-        self.multiplexer_client_1.put(original_envelope)
-        delivered_envelope = self.multiplexer_node_2.get(block=True, timeout=10)
+        self.multiplexers[2].put(envelope)
+        delivered_envelope = self.multiplexers[1].get(block=True, timeout=10)
         assert delivered_envelope is not None
 
-        delivered_envelope.to = addr_1
-        delivered_envelope.sender = addr_n
+        delivered_envelope.to = sender
+        delivered_envelope.sender = to
 
-        self.multiplexer_node_2.put(delivered_envelope)
-        echoed_envelope = self.multiplexer_client_1.get(block=True, timeout=5)
+        self.multiplexers[1].put(delivered_envelope)
+        echoed_envelope = self.multiplexers[2].get(block=True, timeout=5)
 
-        assert echoed_envelope is not None
-        assert echoed_envelope.to == original_envelope.sender
-        assert delivered_envelope.sender == original_envelope.to
-        assert (
-            delivered_envelope.protocol_specification_id
-            == original_envelope.protocol_specification_id
-        )
-        assert delivered_envelope.message == original_envelope.message
+        assert self.sent_is_echoed_envelope(envelope, echoed_envelope)
 
 
 @libp2p_log_on_failure_all
-class TestLibp2pClientConnectionRouting(BaseP2PLibp2pTest):
+class TestLibp2pClientConnectionRouting(TestP2PLibp2pConnectionRouting):
     """Test that libp2p DHT network will reliably route envelopes from clients connected to different nodes"""
 
     @classmethod
     def setup_class(cls):
         """Set the test up"""
-        super().setup_class()
+        BaseP2PLibp2pTest.setup_class()
 
         cls.ports = next(ports), next(ports)
-
-        try:
-            cls.connection_node_1 = _make_libp2p_connection(
-                delegate_port=cls.ports[0],
-                delegate=True,
-            )
-            cls.multiplexer_node_1 = Multiplexer(
-                [cls.connection_node_1], protocols=[MockDefaultMessageProtocol]
-            )
-            cls.log_files.append(cls.connection_node_1.node.log_file)
-            cls.multiplexer_node_1.connect()
-            cls.multiplexers.append(cls.multiplexer_node_1)
-
-            entry_peer = cls.connection_node_1.node.multiaddrs[0]
-
-            cls.connection_node_2 = _make_libp2p_connection(
-                delegate_port=cls.ports[1],
-                entry_peers=[entry_peer],
-                delegate=True,
-            )
-            cls.multiplexer_node_2 = Multiplexer(
-                [cls.connection_node_2], protocols=[MockDefaultMessageProtocol]
-            )
-            cls.log_files.append(cls.connection_node_2.node.log_file)
-            cls.multiplexer_node_2.connect()
-
-            cls.multiplexers.append(cls.multiplexer_node_2)
-
-            wait_for_condition(lambda: cls.multiplexer_node_1.is_connected, 10)
-            wait_for_condition(lambda: cls.multiplexer_node_2.is_connected, 10)
-            wait_for_condition(lambda: cls.connection_node_1.is_connected, 10)
-            wait_for_condition(lambda: cls.connection_node_2.is_connected, 10)
-            cls.connections = [cls.connection_node_1, cls.connection_node_2]
-            cls.addresses = [
-                cls.connection_node_1.address,
-                cls.connection_node_2.address,
-            ]
-
-            for _ in range(DEFAULT_CLIENTS_PER_NODE):
-                peers_public_keys = [
-                    cls.connection_node_1.node.pub,
-                    cls.connection_node_2.node.pub,
-                ]
-                for i, port in enumerate(cls.ports):
-                    peer_public_key = peers_public_keys[i]
-                    conn = _make_libp2p_client_connection(
-                        peer_public_key=peer_public_key,
-                        node_port=port,
-                    )
-                    mux = Multiplexer([conn], protocols=[MockDefaultMessageProtocol])
-
-                    cls.connections.append(conn)
-                    cls.addresses.append(conn.address)
-
-                    mux.connect()
-                    wait_for_condition(lambda: mux.is_connected, 10)
-                    wait_for_condition(lambda: conn.is_connected, 10)
-                    cls.multiplexers.append(mux)
-                break
-
-        except Exception:
-            cls.teardown_class()
-            raise
-
-    def test_connection_is_established(self):
-        """Test connection is established."""
-        for conn in self.connections:
-            assert conn.is_connected is True
-
-    def test_star_routing_connectivity(self):
-        """Test routing with star connectivity."""
-        msg = DefaultMessage(
-            dialogue_reference=("", ""),
-            message_id=1,
-            target=0,
-            performative=DefaultMessage.Performative.BYTES,
-            content=b"hello",
+        connection1 = cls.make_connection(
+            delegate_port=cls.ports[0],
+            delegate=True,
         )
-        nodes = range(len(self.multiplexers))
-        for u, v in permutations(nodes, 2):
-            envelope = Envelope(
-                to=self.addresses[v],
-                sender=self.addresses[u],
-                protocol_specification_id=DefaultMessage.protocol_specification_id,
-                message=DefaultSerializer().encode(msg),
+        entry_peer = connection1.node.multiaddrs[0]
+        connection2 = cls.make_connection(
+            delegate_port=cls.ports[1],
+            entry_peers=[entry_peer],
+            delegate=True,
+        )
+
+        peers_public_keys = [connection1.node.pub, connection2.node.pub]
+        assert len(cls.ports) == len(peers_public_keys)
+        for port, peer_public_key in zip(cls.ports, peers_public_keys):
+            cls.make_client_connection(
+                peer_public_key=peer_public_key,
+                node_port=port,
             )
-
-            self.multiplexers[u].put(envelope)
-            delivered_envelope = self.multiplexers[v].get(block=True, timeout=10)
-            assert delivered_envelope is not None
-            assert delivered_envelope.to == envelope.to
-            assert delivered_envelope.sender == envelope.sender
-            assert (
-                delivered_envelope.protocol_specification_id
-                == envelope.protocol_specification_id
-            )
-            assert delivered_envelope.message == envelope.message
-
-
-def test_libp2pclientconnection_uri():
-    """Test the uri."""
-    uri = Uri(host="127.0.0.1")
-    uri = Uri(host="127.0.0.1", port=10000)
-    assert uri.host == "127.0.0.1" and uri.port == 10000
 
 
 @libp2p_log_on_failure_all
@@ -567,82 +282,21 @@ class BaseTestLibp2pClientSamePeer(BaseP2PLibp2pTest):
         super().setup_class()
 
         cls.delegate_port = next(ports)
-
-        MockDefaultMessageProtocol = Mock()
-        MockDefaultMessageProtocol.protocol_id = DefaultMessage.protocol_id
-        MockDefaultMessageProtocol.protocol_specification_id = (
-            DefaultMessage.protocol_specification_id
-        )
-
-        cls.connection_node = _make_libp2p_connection(
+        cls.connection_node = cls.make_connection(
             delegate=True,
             delegate_port=cls.delegate_port,
         )
-        cls.multiplexer_node = Multiplexer(
-            [cls.connection_node], protocols=[MockDefaultMessageProtocol]
+
+        cls.connection_client_1 = cls.make_client_connection(
+            peer_public_key=cls.connection_node.node.pub,
+            ledger_api_id=LIBP2P_LEDGER,
+            node_port=cls.delegate_port,
         )
-        cls.log_files.append(cls.connection_node.node.log_file)
-        cls.multiplexer_node.connect()
-
-        try:
-            cls.connection_client_1 = _make_libp2p_client_connection(
-                peer_public_key=cls.connection_node.node.pub,
-                ledger_api_id=LIBP2P_LEDGER,
-                node_port=cls.delegate_port,
-            )
-            cls.multiplexer_client_1 = Multiplexer(
-                [cls.connection_client_1], protocols=[MockDefaultMessageProtocol]
-            )
-            cls.multiplexer_client_1.connect()
-
-            cls.connection_client_2 = _make_libp2p_client_connection(
-                peer_public_key=cls.connection_node.node.pub,
-                ledger_api_id=DEFAULT_LEDGER,
-                node_port=cls.delegate_port,
-            )
-            cls.multiplexer_client_2 = Multiplexer(
-                [cls.connection_client_2], protocols=[MockDefaultMessageProtocol]
-            )
-            cls.multiplexer_client_2.connect()
-            wait_for_condition(lambda: cls.multiplexer_client_2.is_connected, 20)
-            wait_for_condition(lambda: cls.multiplexer_client_1.is_connected, 20)
-            wait_for_condition(lambda: cls.connection_client_2.is_connected, 20)
-            wait_for_condition(lambda: cls.connection_client_1.is_connected, 20)
-            wait_for_condition(lambda: cls.connection_node.is_connected, 20)
-        except Exception:
-            cls.multiplexer_node.disconnect()
-            raise
-
-    @classmethod
-    def teardown_class(cls):
-        """Tear down the test"""
-        cls.multiplexer_client_1.disconnect()
-        cls.multiplexer_client_2.disconnect()
-        cls.multiplexer_node.disconnect()
-        super().teardown_class()
-
-    def _make_envelope(
-        self,
-        sender_address: str,
-        receiver_address: str,
-        message_id: int = 1,
-        target: int = 0,
-    ):
-        """Make an envelope for testing purposes."""
-        msg = DefaultMessage(
-            dialogue_reference=("", ""),
-            message_id=message_id,
-            target=target,
-            performative=DefaultMessage.Performative.BYTES,
-            content=b"hello",
+        cls.connection_client_2 = cls.make_client_connection(
+            peer_public_key=cls.connection_node.node.pub,
+            ledger_api_id=DEFAULT_LEDGER,
+            node_port=cls.delegate_port,
         )
-        envelope = Envelope(
-            to=receiver_address,
-            sender=sender_address,
-            protocol_specification_id=DefaultMessage.protocol_specification_id,
-            message=DefaultSerializer().encode(msg),
-        )
-        return envelope
 
 
 @libp2p_log_on_failure_all
@@ -651,34 +305,22 @@ class TestLibp2pClientReconnectionSendEnvelope(BaseTestLibp2pClientSamePeer):
 
     def test_envelope_sent(self):
         """Test the envelope is routed."""
-        addr_1 = self.connection_client_1.address
-        addr_2 = self.connection_client_2.address
-        envelope = self._make_envelope(addr_1, addr_2)
+        sender = self.connection_client_1.address
+        to = self.connection_client_2.address
+        envelope = self.enveloped_default_message(to=to, sender=sender)
 
-        # make the send to fail
+        # cause failure on send
         with mock.patch.object(
             self.connection_client_1.logger, "exception"
         ) as _mock_logger, mock.patch.object(
             self.connection_client_1._node_client, "_write", side_effect=Exception
         ):
-            self.multiplexer_client_1.put(envelope)
-            delivered_envelope = self.multiplexer_client_2.get(block=True, timeout=20)
-            _mock_logger.assert_has_calls(
-                [
-                    call(
-                        "Exception raised on message send. Try reconnect and send again."
-                    )
-                ]
-            )
+            self.multiplexers[1].put(envelope)
+            delivered_envelope = self.multiplexers[2].get(block=True, timeout=TIMEOUT)
+            expected = "Exception raised on message send. Try reconnect and send again."
+            _mock_logger.assert_has_calls([call(expected)])
 
-        assert delivered_envelope is not None
-        assert delivered_envelope.to == envelope.to
-        assert delivered_envelope.sender == envelope.sender
-        assert (
-            delivered_envelope.protocol_specification_id
-            == envelope.protocol_specification_id
-        )
-        assert delivered_envelope.message == envelope.message
+        assert self.sent_is_delivered_envelope(envelope, delivered_envelope)
 
 
 @libp2p_log_on_failure_all
@@ -688,10 +330,10 @@ class TestLibp2pClientReconnectionReceiveEnvelope(BaseTestLibp2pClientSamePeer):
     def test_envelope_received(self):
         """Test the envelope is routed."""
         sender = self.connection_client_2.address
-        receiver = self.connection_client_1.address
-        envelope = self._make_envelope(sender, receiver)
+        to = self.connection_client_1.address
+        envelope = self.enveloped_default_message(to=to, sender=sender)
 
-        # make the receive to fail
+        # make the reception fail
         with mock.patch.object(
             self.connection_client_1.logger, "error"
         ) as _mock_logger, mock.patch.object(
@@ -700,29 +342,14 @@ class TestLibp2pClientReconnectionReceiveEnvelope(BaseTestLibp2pClientSamePeer):
             side_effect=ConnectionError(),
         ):
             # this envelope will be lost.
-            self.multiplexer_client_2.put(envelope)
-            # give time to reconnect
+            self.multiplexers[2].put(envelope)
             time.sleep(2.0)
-            _mock_logger.assert_has_calls(
-                [
-                    call(
-                        RegexComparator(
-                            "Connection error:.*Try to reconnect and read again"
-                        )
-                    )
-                ]
-            )
-        # proceed as usual. Now we expect the connection to have reconnected successfully
-        delivered_envelope = self.multiplexer_client_1.get(block=True, timeout=20)
+            expected = "Connection error:.*Try to reconnect and read again"
+            _mock_logger.assert_has_calls([call(RegexComparator(expected))])
 
-        assert delivered_envelope is not None
-        assert delivered_envelope.to == envelope.to
-        assert delivered_envelope.sender == envelope.sender
-        assert (
-            delivered_envelope.protocol_specification_id
-            == envelope.protocol_specification_id
-        )
-        assert delivered_envelope.message == envelope.message
+        # proceed as usual. Now we expect the connection to have reconnected successfully
+        delivered_envelope = self.multiplexers[1].get(block=True, timeout=20)
+        assert self.sent_is_delivered_envelope(envelope, delivered_envelope)
 
 
 @libp2p_log_on_failure_all
@@ -733,54 +360,26 @@ class TestLibp2pClientEnvelopeOrderSamePeer(BaseTestLibp2pClientSamePeer):
 
     def test_burst_order(self):
         """Test order of envelope burst is guaranteed on receiving end."""
-        addr_1 = self.connection_client_1.address
-        addr_2 = self.connection_client_2.address
 
+        sender = self.connection_client_1.address
+        to = self.connection_client_2.address
         sent_envelopes = [
-            self._make_envelope(addr_1, addr_2, i + 1, i)
-            for i in range(self.NB_ENVELOPES)
+            self.enveloped_default_message(to, sender) for _ in range(self.NB_ENVELOPES)
         ]
+
         for envelope in sent_envelopes:
-            self.multiplexer_client_1.put(envelope)
+            envelope.message = envelope.message_bytes  # encode
+            self.multiplexers[1].put(envelope)
 
         received_envelopes = []
         for _ in range(self.NB_ENVELOPES):
-            envelope = self.multiplexer_client_2.get(block=True, timeout=20)
+            envelope = self.multiplexers[2].get(block=True, timeout=3)
             received_envelopes.append(envelope)
 
         # test no new message is "created"
         with pytest.raises(Empty):
-            self.multiplexer_client_2.get(block=True, timeout=1)
+            self.multiplexers[2].get(block=True, timeout=1)
 
-        assert len(sent_envelopes) == len(
-            received_envelopes
-        ), f"expected number of envelopes {len(sent_envelopes)}, got {len(received_envelopes)}"
+        assert len(sent_envelopes) == len(received_envelopes)
         for expected, actual in zip(sent_envelopes, received_envelopes):
-            assert expected.message == actual.message, (
-                "message content differ; probably a wrong message "
-                "ordering on the receiving end"
-            )
-
-
-@pytest.mark.asyncio
-async def test_nodeclient_pipe_connect():
-    """Test pipe.connect called on NodeClient.connect."""
-    f = asyncio.Future()
-    f.set_result(None)
-    pipe = Mock()
-    pipe.connect.return_value = f
-    node_client = NodeClient(pipe, Mock())
-    await node_client.connect()
-    pipe.connect.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_write_acn_error():
-    """Test pipe.connect called on NodeClient.connect."""
-    f = asyncio.Future()
-    f.set_result(None)
-    pipe = Mock()
-    pipe.write.return_value = f
-    node_client = NodeClient(pipe, Mock())
-    await node_client.write_acn_status_error("some message")
-    pipe.write.assert_called_once()
+            assert expected.message == actual.message

--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_errors.py
@@ -39,10 +39,10 @@ from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     _make_libp2p_client_connection,
     _make_libp2p_connection,
     _process_cert,
-    libp2p_log_on_failure_all,
-    ports,
     create_identity,
+    libp2p_log_on_failure_all,
     make_cert_request,
+    ports,
 )
 
 
@@ -86,7 +86,10 @@ class TestLibp2pClientConnectionFailureNodeNotConnected(BaseP2PLibp2pTest):
         exception_future.set_exception(ConnectionError("oops"))
         result = Future()
         result.set_result(None)
-        self.connection._node_client.read_envelope.side_effect = [exception_future, result]
+        self.connection._node_client.read_envelope.side_effect = [
+            exception_future,
+            result,
+        ]
 
         with patch.object(
             self.connection, "_perform_connection_to_node", return_value=DONE_FUTURE
@@ -104,7 +107,9 @@ class TestLibp2pClientConnectionFailureNodeNotConnected(BaseP2PLibp2pTest):
         self.connection._node_client.send_envelope.side_effect = Exception("oops")
         with patch.object(
             self.connection, "_perform_connection_to_node", return_value=DONE_FUTURE
-        ) as connect_mock, patch.object(self.connection, "_ensure_valid_envelope_for_external_comms"):
+        ) as connect_mock, patch.object(
+            self.connection, "_ensure_valid_envelope_for_external_comms"
+        ):
             with pytest.raises(Exception, match="oops"):
                 await self.connection._send_envelope_with_node_client(Mock())
             connect_mock.assert_called()
@@ -148,7 +153,9 @@ class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
         crypto.dump(cls.key_file)
         cls.public_key = cls.default_crypto.public_key
         ledger = cls.default_crypto.identifier
-        cls.cert_request = make_cert_request(cls.public_key, ledger, f"./{crypto.address}")
+        cls.cert_request = make_cert_request(
+            cls.public_key, ledger, f"./{crypto.address}"
+        )
         _process_cert(crypto, cls.cert_request, cls.tmp)
 
     def test_empty_nodes(self):
@@ -236,7 +243,9 @@ class TestLibp2pClientConnectionCheckSignature(BaseP2PLibp2pTest):
         self.connection.connect_retries = 1
         try:
             self.connection.node_por._representative_public_key = key.public_key
-            expected = ".*Invalid TLS session key signature: Signature verification failed.*"
+            expected = (
+                ".*Invalid TLS session key signature: Signature verification failed.*"
+            )
             with pytest.raises(ValueError, match=expected):
                 await self.connection.connect()
             assert self.connection.is_connected is False

--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_errors.py
@@ -28,212 +28,91 @@ from unittest.mock import Mock, patch
 import pytest
 
 from aea.configurations.base import ConnectionConfig
-from aea.configurations.constants import DEFAULT_LEDGER
-from aea.crypto.registries import make_crypto
-from aea.helpers.base import CertRequest
-from aea.identity.base import Identity
-from aea.multiplexer import Multiplexer
 
-from packages.valory.connections.p2p_libp2p.consts import (
-    LIBP2P_CERT_NOT_AFTER,
-    LIBP2P_CERT_NOT_BEFORE,
-)
 from packages.valory.connections.p2p_libp2p_client.connection import (
     NodeClient,
     P2PLibp2pClientConnection,
-    POR_DEFAULT_SERVICE_ID,
 )
 
 from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     BaseP2PLibp2pTest,
-    LIBP2P_LEDGER,
     _make_libp2p_client_connection,
     _make_libp2p_connection,
     _process_cert,
     libp2p_log_on_failure_all,
     ports,
+    create_identity,
+    make_cert_request,
 )
 
 
+DONE_FUTURE: asyncio.Future = asyncio.Future()
+DONE_FUTURE.set_result(None)
+
+
 @pytest.mark.asyncio
-class TestLibp2pClientConnectionFailureNodeNotConnected:
+class TestLibp2pClientConnectionFailureNodeNotConnected(BaseP2PLibp2pTest):
     """Test that connection fails when node not running"""
+
+    public_key = BaseP2PLibp2pTest.default_crypto.public_key
+    connection = _make_libp2p_client_connection(peer_public_key=public_key)
 
     @pytest.mark.asyncio
     async def test_node_not_running(self):
         """Test the node is not running."""
-        conn = _make_libp2p_client_connection(
-            peer_public_key=make_crypto(DEFAULT_LEDGER).public_key
-        )
         with pytest.raises(Exception):
-            await conn.connect()
+            await self.connection.connect()
 
+    @pytest.mark.asyncio
+    async def test_connect_attempts(self):
+        """Test connect attempts."""
 
-@libp2p_log_on_failure_all
-class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
-    """Test that connection fails when setup incorrectly"""
+        self.connection.connect_retries = 2
+        with patch(
+            "aea.helpers.pipe.TCPSocketChannelClient.connect",
+            side_effect=Exception("test exception on connect"),
+        ) as open_connection_mock:
+            with pytest.raises(Exception, match="test exception on connect"):
+                await self.connection.connect()
+            assert open_connection_mock.call_count == self.connection.connect_retries
 
-    @classmethod
-    def setup_class(cls):
-        """Set the test up"""
-        super().setup_class()
+    @pytest.mark.asyncio
+    async def test_reconnect_on_receive_fail(self):
+        """Test reconnect on receive fails."""
 
-        crypto = make_crypto(DEFAULT_LEDGER)
-        cls.node_host = "localhost"
-        cls.node_port = "11234"
-        cls.identity = Identity(
-            "identity", address=crypto.address, public_key=crypto.public_key
-        )
+        self.connection._in_queue = Mock()
+        self.connection._node_client = Mock()
+        exception_future = Future()
+        exception_future.set_exception(ConnectionError("oops"))
+        result = Future()
+        result.set_result(None)
+        self.connection._node_client.read_envelope.side_effect = [exception_future, result]
 
-        cls.key_file = os.path.join(cls.tmp, "keyfile")
-        crypto.dump(cls.key_file)
+        with patch.object(
+            self.connection, "_perform_connection_to_node", return_value=DONE_FUTURE
+        ) as connect_mock:
+            assert await self.connection._read_envelope_from_node() is None
+            connect_mock.assert_called()
 
-        cls.peer_crypto = make_crypto(DEFAULT_LEDGER)
-        cls.cert_request = CertRequest(
-            cls.peer_crypto.public_key,
-            POR_DEFAULT_SERVICE_ID,
-            DEFAULT_LEDGER,
-            LIBP2P_CERT_NOT_BEFORE,
-            LIBP2P_CERT_NOT_AFTER,
-            "{public_key}",
-            f"./{crypto.address}_cert.txt",
-        )
-        _process_cert(crypto, cls.cert_request, cls.tmp)
+    @pytest.mark.asyncio
+    async def test_reconnect_on_send_fail(self):
+        """Test reconnect on send fails."""
 
-    def test_empty_nodes(self):
-        """Test empty nodes."""
-        configuration = ConnectionConfig(
-            tcp_key_file=self.key_file,
-            nodes=[
-                {
-                    "uri": "{}:{}".format(self.node_host, self.node_port),
-                    "public_key": self.peer_crypto.public_key,
-                }
-            ],
-            connection_id=P2PLibp2pClientConnection.connection_id,
-            cert_requests=[self.cert_request],
-        )
-        P2PLibp2pClientConnection(
-            configuration=configuration, data_dir=self.tmp, identity=self.identity
-        )
-
-        configuration = ConnectionConfig(
-            tcp_key_file=self.key_file,
-            nodes=None,
-            connection_id=P2PLibp2pClientConnection.connection_id,
-        )
-        with pytest.raises(Exception):
-            P2PLibp2pClientConnection(
-                configuration=configuration,
-                data_dir=self.tmp,
-                identity=self.identity,
-            )
-
-
-@libp2p_log_on_failure_all
-class TestLibp2pClientConnectionNodeDisconnected(BaseP2PLibp2pTest):
-    """Test that connection will properly handle node disconnecting"""
-
-    @classmethod
-    def setup_class(cls):
-        """Set the test up"""
-        super().setup_class()
-
-        cls.delegate_port = next(ports)
-
-        try:
-            cls.connection_node = _make_libp2p_connection(
-                delegate=True,
-                delegate_port=cls.delegate_port,
-            )
-            cls.multiplexer_node = Multiplexer([cls.connection_node])
-            cls.log_files.append(cls.connection_node.node.log_file)
-            cls.multiplexer_node.connect()
-            cls.multiplexers.append(cls.multiplexer_node)
-
-            cls.connection_client = _make_libp2p_client_connection(
-                peer_public_key=cls.connection_node.node.pub,
-                node_port=cls.delegate_port,
-            )
-            cls.multiplexer_client = Multiplexer([cls.connection_client])
-            cls.multiplexer_client.connect()
-            cls.multiplexers.append(cls.multiplexer_client)
-        except Exception:
-            cls.teardown_class()
-            raise
-
-    def test_node_disconnected(self):
-        """Test node disconnected."""
-        assert self.connection_client.is_connected is True
-        self.multiplexer_client.disconnect()
-        self.multiplexer_node.disconnect()
-
-
-done_future: asyncio.Future = asyncio.Future()
-done_future.set_result(None)
-
-
-@pytest.mark.asyncio
-async def test_connect_attempts():
-    """Test connect attempts."""
-    # test connects
-    con = _make_libp2p_client_connection(
-        peer_public_key=make_crypto(DEFAULT_LEDGER).public_key
-    )
-    con.connect_retries = 2
-    with patch(
-        "aea.helpers.pipe.TCPSocketChannelClient.connect",
-        side_effect=Exception("test exception on connect"),
-    ) as open_connection_mock:
-        with pytest.raises(Exception, match="test exception on connect"):
-            await con.connect()
-        assert open_connection_mock.call_count == con.connect_retries
-
-
-@pytest.mark.asyncio
-async def test_reconnect_on_receive_fail():
-    """Test reconnect on receive fails."""
-
-    con = _make_libp2p_client_connection(
-        peer_public_key=make_crypto(DEFAULT_LEDGER).public_key
-    )
-    con._in_queue = Mock()
-    con._node_client = Mock()
-    exception_future = Future()
-    exception_future.set_exception(ConnectionError("oops"))
-    result = Future()
-    result.set_result(None)
-    con._node_client.read_envelope.side_effect = [exception_future, result]
-
-    with patch.object(
-        con, "_perform_connection_to_node", return_value=done_future
-    ) as connect_mock:
-        assert await con._read_envelope_from_node() is None
-        connect_mock.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_reconnect_on_send_fail():
-    """Test reconnect on send fails."""
-    con = _make_libp2p_client_connection(
-        peer_public_key=make_crypto(DEFAULT_LEDGER).public_key
-    )
-    con._node_client = Mock()
-    f = Future()
-    f.set_exception(Exception("oops"))
-    con._node_client.send_envelope.side_effect = Exception("oops")
-    # test reconnect on send fails
-    with patch.object(
-        con, "_perform_connection_to_node", return_value=done_future
-    ) as connect_mock, patch.object(con, "_ensure_valid_envelope_for_external_comms"):
-        with pytest.raises(Exception, match="oops"):
-            await con._send_envelope_with_node_client(Mock())
-        connect_mock.assert_called()
+        self.connection._node_client = Mock()
+        f = Future()
+        f.set_exception(Exception("oops"))
+        self.connection._node_client.send_envelope.side_effect = Exception("oops")
+        with patch.object(
+            self.connection, "_perform_connection_to_node", return_value=DONE_FUTURE
+        ) as connect_mock, patch.object(self.connection, "_ensure_valid_envelope_for_external_comms"):
+            with pytest.raises(Exception, match="oops"):
+                await self.connection._send_envelope_with_node_client(Mock())
+            connect_mock.assert_called()
 
 
 @pytest.mark.asyncio
 async def test_acn_decode_error_on_read():
-    """Test nodeclient send fails on read."""
+    """Test node client send fails on read."""
     f = Future()
     f.set_result(b"some_data")
     pipe = Mock()
@@ -248,6 +127,83 @@ async def test_acn_decode_error_on_read():
         await node_client.read_envelope()
 
     mocked_write_acn_status_error.assert_called_once()
+
+
+@libp2p_log_on_failure_all
+class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
+    """Test that connection fails when setup incorrectly"""
+
+    connection_cls = P2PLibp2pClientConnection
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up"""
+        BaseP2PLibp2pTest.setup_class()
+
+        crypto = cls.ethereum_crypto
+        cls.node_host = "localhost"
+        cls.node_port = next(ports)
+        cls.identity = create_identity(crypto)
+        cls.key_file = os.path.join(cls.tmp, "keyfile")
+        crypto.dump(cls.key_file)
+        cls.public_key = cls.default_crypto.public_key
+        ledger = cls.default_crypto.identifier
+        cls.cert_request = make_cert_request(cls.public_key, ledger, f"./{crypto.address}")
+        _process_cert(crypto, cls.cert_request, cls.tmp)
+
+    def test_empty_nodes(self):
+        """Test empty nodes."""
+
+        uri = f"{self.node_host}:{self.node_port}"
+        node = {"uri": uri, "public_key": self.public_key}
+        configuration = ConnectionConfig(
+            tcp_key_file=self.key_file,
+            nodes=[node],
+            connection_id=self.connection_cls.connection_id,
+            cert_requests=[self.cert_request],
+        )
+        self.connection_cls(
+            configuration=configuration, data_dir=self.tmp, identity=self.identity
+        )
+
+        configuration = ConnectionConfig(
+            tcp_key_file=self.key_file,
+            nodes=None,
+            connection_id=self.connection_cls.connection_id,
+        )
+        with pytest.raises(Exception):
+            self.connection_cls(
+                configuration=configuration,
+                data_dir=self.tmp,
+                identity=self.identity,
+            )
+
+
+@libp2p_log_on_failure_all
+class TestLibp2pClientConnectionNodeDisconnected(BaseP2PLibp2pTest):
+    """Test that connection will properly handle node disconnecting"""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up"""
+        BaseP2PLibp2pTest.setup_class()
+
+        delegate_port = next(ports)
+        cls.connection_node = cls.make_connection(
+            delegate=True,
+            delegate_port=delegate_port,
+        )
+        cls.connection_client = cls.make_client_connection(
+            peer_public_key=cls.connection_node.node.pub,
+            node_port=delegate_port,
+        )
+
+    def test_node_disconnected(self):
+        """Test node disconnected."""
+        assert self.all_connected
+        self.multiplexers[1].disconnect()
+        self.multiplexers[0].disconnect()
+        assert self.all_disconnected
 
 
 @pytest.mark.asyncio
@@ -273,17 +229,15 @@ class TestLibp2pClientConnectionCheckSignature(BaseP2PLibp2pTest):
     @pytest.mark.asyncio
     async def test_signature_check_fail(self):
         """Test signature check failed."""
-        key = make_crypto(LIBP2P_LEDGER)
 
+        key = self.libp2p_crypto
         assert self.connection.is_connected is False
         await self.connection_node.connect()
         self.connection.connect_retries = 1
         try:
             self.connection.node_por._representative_public_key = key.public_key
-            with pytest.raises(
-                ValueError,
-                match=".*Invalid TLS session key signature: Signature verification failed.*",
-            ):
+            expected = ".*Invalid TLS session key signature: Signature verification failed.*"
+            with pytest.raises(ValueError, match=expected):
                 await self.connection.connect()
             assert self.connection.is_connected is False
         finally:

--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_errors.py
@@ -85,7 +85,7 @@ class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
             "identity", address=crypto.address, public_key=crypto.public_key
         )
 
-        cls.key_file = os.path.join(cls.t, "keyfile")
+        cls.key_file = os.path.join(cls.tmp, "keyfile")
         crypto.dump(cls.key_file)
 
         cls.peer_crypto = make_crypto(DEFAULT_LEDGER)
@@ -98,7 +98,7 @@ class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
             "{public_key}",
             f"./{crypto.address}_cert.txt",
         )
-        _process_cert(crypto, cls.cert_request, cls.t)
+        _process_cert(crypto, cls.cert_request, cls.tmp)
 
     def test_empty_nodes(self):
         """Test empty nodes."""
@@ -114,7 +114,7 @@ class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
             cert_requests=[self.cert_request],
         )
         P2PLibp2pClientConnection(
-            configuration=configuration, data_dir=self.t, identity=self.identity
+            configuration=configuration, data_dir=self.tmp, identity=self.identity
         )
 
         configuration = ConnectionConfig(
@@ -125,7 +125,7 @@ class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
         with pytest.raises(Exception):
             P2PLibp2pClientConnection(
                 configuration=configuration,
-                data_dir=self.t,
+                data_dir=self.tmp,
                 identity=self.identity,
             )
 

--- a/tests/test_packages/test_connections/test_p2p_libp2p_mailbox/test_aea_cli.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_mailbox/test_aea_cli.py
@@ -24,9 +24,7 @@ from packages.valory.connections import p2p_libp2p_mailbox
 from packages.valory.connections.p2p_libp2p_mailbox.connection import PUBLIC_ID
 
 from tests.conftest import DEFAULT_HOST
-from tests.test_packages.test_connections.test_p2p_libp2p.base import (
-    ports,
-)
+from tests.test_packages.test_connections.test_p2p_libp2p.base import ports
 from tests.test_packages.test_connections.test_p2p_libp2p_client.test_aea_cli import (
     TestP2PLibp2pClientConnectionAEARunning as Base,
 )
@@ -35,7 +33,9 @@ from tests.test_packages.test_connections.test_p2p_libp2p_client.test_aea_cli im
 class TestP2PLibp2pMailboxConnectionAEARunning(Base):
     """Test AEA with p2p_libp2p_client connection is correctly run"""
 
-    conn_path = p2p_libp2p_mailbox_path = f"vendor.{p2p_libp2p_mailbox.__name__.split('.', 1)[-1]}"
+    conn_path = (
+        p2p_libp2p_mailbox_path
+    ) = f"vendor.{p2p_libp2p_mailbox.__name__.split('.', 1)[-1]}"
     public_id = str(PUBLIC_ID)
     port = next(ports)
     uri = f"{DEFAULT_HOST}:{port}"

--- a/tests/test_packages/test_connections/test_p2p_libp2p_mailbox/test_aea_cli.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_mailbox/test_aea_cli.py
@@ -20,114 +20,28 @@
 
 """This test module contains AEA cli tests for Libp2p tcp client connection."""
 
-import json
-
-from aea.helpers.base import CertRequest
-from aea.multiplexer import Multiplexer
-from aea.test_tools.test_cases import AEATestCaseEmpty
-
 from packages.valory.connections import p2p_libp2p_mailbox
-from packages.valory.connections.p2p_libp2p.consts import (
-    LIBP2P_CERT_NOT_AFTER,
-    LIBP2P_CERT_NOT_BEFORE,
-)
 from packages.valory.connections.p2p_libp2p_mailbox.connection import PUBLIC_ID
 
-from tests.conftest import DEFAULT_HOST, DEFAULT_LEDGER
+from tests.conftest import DEFAULT_HOST
 from tests.test_packages.test_connections.test_p2p_libp2p.base import (
-    _make_libp2p_connection,
-    libp2p_log_on_failure_all,
     ports,
+)
+from tests.test_packages.test_connections.test_p2p_libp2p_client.test_aea_cli import (
+    TestP2PLibp2pClientConnectionAEARunning as Base,
 )
 
 
-p2p_libp2p_mailbox_path = f"vendor.{p2p_libp2p_mailbox.__name__.split('.', 1)[-1]}"
-DEFAULT_CLIENTS_PER_NODE = 4
-DEFAULT_LAUNCH_TIMEOUT = 10
-
-
-@libp2p_log_on_failure_all
-class TestP2PLibp2pClientConnectionAEARunning(AEATestCaseEmpty):
+class TestP2PLibp2pMailboxConnectionAEARunning(Base):
     """Test AEA with p2p_libp2p_client connection is correctly run"""
 
-    @classmethod
-    def setup_class(cls):
-        """Set up the test class."""
-        super().setup_class()
-
-        cls.mailbox_port = next(ports)
-        cls.node_connection = _make_libp2p_connection(
-            delegate_host=DEFAULT_HOST,
-            mailbox_port=cls.mailbox_port,
-            delegate=True,
-            mailbox=True,
-        )
-        cls.node_multiplexer = Multiplexer([cls.node_connection])
-        cls.log_files = [cls.node_connection.node.log_file]
-        cls.node_multiplexer.connect()
-
-    def test_node(self):
-        """Test the node is connected."""
-        assert self.node_connection.is_connected is True
-
-    def test_connection(self):
-        """Test the connection can be used in an aea."""
-        ledger_id = DEFAULT_LEDGER
-        self.generate_private_key(ledger_id)
-        self.add_private_key(ledger_id, f"{ledger_id}_private_key.txt")
-        self.set_config("agent.default_ledger", ledger_id)
-        self.set_config("agent.required_ledgers", json.dumps([ledger_id]), "list")
-        self.add_item("connection", str(PUBLIC_ID))
-        conn_path = p2p_libp2p_mailbox_path
-        self.nested_set_config(
-            conn_path + ".config",
-            {
-                "nodes": [
-                    {
-                        "uri": "{}:{}".format(DEFAULT_HOST, self.mailbox_port),
-                        "public_key": self.node_connection.node.pub,
-                    }
-                ]
-            },
-        )
-
-        # generate certificates for connection
-        self.nested_set_config(
-            conn_path + ".cert_requests",
-            [
-                CertRequest(
-                    identifier="acn",
-                    ledger_id=ledger_id,
-                    not_before=LIBP2P_CERT_NOT_BEFORE,
-                    not_after=LIBP2P_CERT_NOT_AFTER,
-                    public_key=self.node_connection.node.pub,
-                    message_format="{public_key}",
-                    save_path="./cli_test_cert.txt",
-                )
-            ],
-        )
-        self.run_cli_command("issue-certificates", cwd=self._get_cwd())
-
-        process = self.run_agent()
-        is_running = self.is_running(process, timeout=DEFAULT_LAUNCH_TIMEOUT)
-        assert is_running, "AEA not running within timeout!"
-
-        check_strings = "Successfully connected to libp2p node {}:{}".format(
-            DEFAULT_HOST, self.mailbox_port
-        )
-        missing_strings = self.missing_from_output(process, check_strings)
-        assert (
-            missing_strings == []
-        ), "Strings {} didn't appear in agent output.".format(missing_strings)
-
-        self.terminate_agents(process)
-        assert self.is_successfully_terminated(
-            process
-        ), "AEA wasn't successfully terminated."
-
-    @classmethod
-    def teardown_class(cls):
-        """Tear down the test"""
-        cls.terminate_agents()
-        super(TestP2PLibp2pClientConnectionAEARunning, cls).teardown_class()
-        cls.node_multiplexer.disconnect()
+    conn_path = p2p_libp2p_mailbox_path = f"vendor.{p2p_libp2p_mailbox.__name__.split('.', 1)[-1]}"
+    public_id = str(PUBLIC_ID)
+    port = next(ports)
+    uri = f"{DEFAULT_HOST}:{port}"
+    kwargs = dict(
+        delegate_host=DEFAULT_HOST,
+        mailbox_port=port,
+        delegate=True,
+        mailbox=True,
+    )

--- a/tests/test_packages/test_connections/test_p2p_libp2p_mailbox/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_mailbox/test_errors.py
@@ -83,7 +83,7 @@ class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
             "identity", address=crypto.address, public_key=crypto.public_key
         )
 
-        cls.key_file = os.path.join(cls.t, "keyfile")
+        cls.key_file = os.path.join(cls.tmp, "keyfile")
         crypto.dump(cls.key_file)
 
         cls.peer_crypto = make_crypto(DEFAULT_LEDGER)
@@ -96,7 +96,7 @@ class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
             "{public_key}",
             f"./{crypto.address}_cert.txt",
         )
-        _process_cert(crypto, cls.cert_request, cls.t)
+        _process_cert(crypto, cls.cert_request, cls.tmp)
 
     def test_empty_nodes(self):
         """Test empty nodes."""
@@ -112,7 +112,7 @@ class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
             cert_requests=[self.cert_request],
         )
         P2PLibp2pMailboxConnection(
-            configuration=configuration, data_dir=self.t, identity=self.identity
+            configuration=configuration, data_dir=self.tmp, identity=self.identity
         )
 
         configuration = ConnectionConfig(
@@ -123,7 +123,7 @@ class TestLibp2pClientConnectionFailureConnectionSetup(BaseP2PLibp2pTest):
         with pytest.raises(Exception):
             P2PLibp2pMailboxConnection(
                 configuration=configuration,
-                data_dir=self.t,
+                data_dir=self.tmp,
                 identity=self.identity,
             )
 

--- a/tests/test_packages/test_connections/test_p2p_libp2p_mailbox/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_mailbox/test_errors.py
@@ -25,12 +25,15 @@ import pytest
 from packages.valory.connections.p2p_libp2p_mailbox.connection import (
     P2PLibp2pMailboxConnection,
 )
+
 from tests.test_packages.test_connections.test_p2p_libp2p.base import (
     BaseP2PLibp2pTest,
     _make_libp2p_mailbox_connection,
 )
 from tests.test_packages.test_connections.test_p2p_libp2p_client.test_errors import (
     TestLibp2pClientConnectionFailureConnectionSetup as BaseFailureConnectionSetup,
+)
+from tests.test_packages.test_connections.test_p2p_libp2p_client.test_errors import (
     TestLibp2pClientConnectionFailureNodeNotConnected as BaseFailureNodeNotConnected,
 )
 
@@ -40,7 +43,7 @@ class TestLibp2pMailboxConnectionFailureNodeNotConnected(BaseFailureNodeNotConne
     """Test that connection fails when node not running"""
 
     public_key = BaseP2PLibp2pTest.default_crypto.public_key
-    connection = _make_libp2p_mailbox_connection(peer_public_key=public_key)
+    connection = _make_libp2p_mailbox_connection(peer_public_key=public_key)  # type: ignore
     # overwrite, no mailbox equivalent of P2PLibp2pClientConnection (TCPSocketChannelClient)
     test_connect_attempts = None
 
@@ -48,4 +51,4 @@ class TestLibp2pMailboxConnectionFailureNodeNotConnected(BaseFailureNodeNotConne
 class TestLibp2pMailboxConnectionFailureConnectionSetup(BaseFailureConnectionSetup):
     """Test that connection fails when setup incorrectly"""
 
-    connection_cls = P2PLibp2pMailboxConnection
+    connection_cls = P2PLibp2pMailboxConnection  # type: ignore


### PR DESCRIPTION
## Proposed changes

Part of incremental fixes and refactoring of ACN tests. Refactoring is part of the fixes because the amount of duplicated code, with slight alterations in various places, makes if hard to spot and debug issues.

## Fixes

- auto assign multiplexers in base class to ensure disconnection via `atexit` registration on class setup
- match error messages in pytest.raises
- clean-up fault tolerance tests: assign proper protocol (fix)
- remove all remaining pytest flakiness markers
- remove a meaningless test: `TestP2PLibp2pConnectionFailureNodeDisconnect`
- remove duplicated tests `test_nodeclient_pipe_connect` and `test_write_acn_error` (present in `test_p2p_libp2p/test_communication.py`, removed from `p2p_libp2p_client/test_communication.py` )
- introduce `teardown` and `setup` methods to `TestLibp2pConnectionPublicDHTRelay` and `TestLibp2pConnectionPublicDHTDelegate` to prevent tests interfering with one-another
- simplify and remove needless code

I also introduce the same changes to `test_p2p_libp2p_client` and `test_p2p_libp2p_mailbox` as introduced to `test_p2p_libp2p` in #231 


## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
