### PR TITLE
Release v1.15.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -173,7 +173,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -172,6 +172,8 @@ jobs:
     if: github.base_ref == 'main'
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"

--- a/.spelling
+++ b/.spelling
@@ -283,6 +283,7 @@ io
 v1
 v0
 ipfsdaemon
+py3.6
  - docs/language-agnostic-definition.md
 fetchai
 protocol_id

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,15 @@
 # Release History - open AEA
 
+## 1.15.0 (2022-08-01)
+
+AEA:
+- Updates the protocol generator to use `protocol generator version` as a header rather than using framework version
+
+Chore:
+- Cleans up remnants of py3.6
+- Updated the release process
+- Adds skaffold profiles for releases
+
 ## 1.14.0 (2022-07-29)
 
 AEA:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-aea` are currently being suppo
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `1.14.x`   | :white_check_mark: |
-| `< 1.14.0` | :x:                |
+| `1.15.x`   | :white_check_mark: |
+| `< 1.15.0` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.14.0"
+__version__ = "1.15.0"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.14.0
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.15.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.14.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.15.0/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.14.0
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.15.0
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,6 +7,12 @@ Below we describe the additional manual steps required to upgrade between differ
 
 # Open AEA
 
+## `v1.14.0` to `v1.15.0`
+
+No backwards incompatible changes.
+
+Plugins from previous versions are not compatible anymore.
+
 ## `v1.13.0` to `v1.14.0`
 
 No backwards incompatible changes.

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.14.0
+RUN pip install --upgrade --force-reinstall aea[all]==1.15.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-benchmark",
-    version="1.14.0",
+    version="1.15.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.14.0",
+    version="1.15.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.14.0",
+    version="1.15.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.14.0",
+    version="1.15.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.14.0",
+    version="1.15.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",

--- a/scripts/RELEASE_PROCESS.md
+++ b/scripts/RELEASE_PROCESS.md
@@ -40,7 +40,7 @@
 
 18. Publish the latest packages to the IPFS registry using `aea push-all`. If necessary, run it several times until all packages are updated.
 
-19. Build the release images using `skaffold build -p release` which will also publish them on docker. This builds with no cache so to ensure replicatable builds.
+19. Build the release images using `skaffold build -p release` which will also publish them on docker. This builds with no cache so to ensure replicable builds.
 
 20. Tag the latest images using `skaffold build -p release-latest` which will also publish them on docker.
 

--- a/scripts/check_ipfs_hashes_pushed.py
+++ b/scripts/check_ipfs_hashes_pushed.py
@@ -84,6 +84,6 @@ if __name__ == "__main__":
             errors.append(h)
 
     if errors:
-        print("The following hashes were not found in IPFS registry: {errors}")
+        print(f"The following hashes were not found in IPFS registry: {errors}")
         sys.exit(1)
     print("OK")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.14.0 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.15.0 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.14.0 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.15.0 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.14.0"
+      template: "1.15.0"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -25,7 +25,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.14.0"
+          template: "1.15.0"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -44,7 +44,7 @@ pip install open-aea[all]
 pip install open-aea-cli-ipfs
 ```
 ```
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.14.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.15.0/packages packages
 ```
 
 ``` bash

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.14.0
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.15.0
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.15.0

## Release details

AEA:
- Updates the protocol generator to use `protocol generator version` as a header rather than using framework version

Chore:
- Cleans up remnants of py3.6
- Updated the release process
- Adds skaffold profiles for releases

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side), from `develop`
- [x] Lint and unit tests pass locally and in CI
- [x] I have checked the fingerprint hashes are correct by running (`aea hash all --check`)
- [x] I have regenerated the latest API docs
- [x] I built the documentation and updated it with the latest changes
- [x] I have added an item in `HISTORY.md` for this release
- [x] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.
