### PR TITLE
Fix #252

### DIFF
--- a/aea/cli/ipfs_hash.py
+++ b/aea/cli/ipfs_hash.py
@@ -44,7 +44,7 @@ from aea.configurations.constants import (
 from aea.configurations.data_types import PackageId, PublicId
 from aea.configurations.loader import load_configuration_object
 from aea.helpers.cid import DEFAULT_ENCODING, to_v0, to_v1
-from aea.helpers.dependency_tree import DependecyTree, dump_yaml, load_yaml, to_plural
+from aea.helpers.dependency_tree import DependencyTree, dump_yaml, load_yaml, to_plural
 from aea.helpers.fingerprint import check_fingerprint, update_fingerprint
 from aea.helpers.io import from_csv, to_csv
 from aea.helpers.ipfs.base import IPFSHashOnly
@@ -214,7 +214,7 @@ def update_hashes(
 
     try:
         public_id_to_hash_mappings: Dict = {}
-        dependency_tree = DependecyTree.generate(packages_dir)
+        dependency_tree = DependencyTree.generate(packages_dir)
         packages = [
             [package_id_and_path(package_id, packages_dir) for package_id in tree_level]
             for tree_level in dependency_tree

--- a/aea/helpers/dependency_tree.py
+++ b/aea/helpers/dependency_tree.py
@@ -97,7 +97,7 @@ def to_package_id(public_id: str, package_type: str) -> PackageId:
     return PackageId(package_type, PublicId.from_str(public_id)).without_hash()
 
 
-class DependecyTree:
+class DependencyTree:
     """This class represents the dependency tree for a registry."""
 
     @staticmethod

--- a/docs/api/helpers/dependency_tree.md
+++ b/docs/api/helpers/dependency_tree.md
@@ -66,17 +66,17 @@ def to_package_id(public_id: str, package_type: str) -> PackageId
 
 Convert to public id.
 
-<a id="aea.helpers.dependency_tree.DependecyTree"></a>
+<a id="aea.helpers.dependency_tree.DependencyTree"></a>
 
-## DependecyTree Objects
+## DependencyTree Objects
 
 ```python
-class DependecyTree()
+class DependencyTree()
 ```
 
 This class represents the dependency tree for a registry.
 
-<a id="aea.helpers.dependency_tree.DependecyTree.get_all_dependencies"></a>
+<a id="aea.helpers.dependency_tree.DependencyTree.get_all_dependencies"></a>
 
 #### get`_`all`_`dependencies
 
@@ -87,19 +87,27 @@ def get_all_dependencies(item_config: Dict) -> List[PackageId]
 
 Returns a list of all available dependencies.
 
-<a id="aea.helpers.dependency_tree.DependecyTree.resolve_tree"></a>
+<a id="aea.helpers.dependency_tree.DependencyTree.resolve_tree"></a>
 
 #### resolve`_`tree
 
 ```python
 @classmethod
-def resolve_tree(cls, dependency_list: Dict[PackageId, List[PackageId]],
-                 tree: Dict) -> None
+def resolve_tree(cls, dependency_list: Dict[PackageId,
+                                            List[PackageId]]) -> Dict
 ```
 
-Resolve dependency tree
+Resolve dependency tree.
 
-<a id="aea.helpers.dependency_tree.DependecyTree.flatten_tree"></a>
+**Arguments**:
+
+- `dependency_list`: the adjacency list of the dependency graph
+
+**Returns**:
+
+the dependency tree
+
+<a id="aea.helpers.dependency_tree.DependencyTree.flatten_tree"></a>
 
 #### flatten`_`tree
 
@@ -111,7 +119,7 @@ def flatten_tree(cls, dependency_tree: Dict, flat_tree: List[List[PackageId]],
 
 Flatten tree.
 
-<a id="aea.helpers.dependency_tree.DependecyTree.generate"></a>
+<a id="aea.helpers.dependency_tree.DependencyTree.generate"></a>
 
 #### generate
 

--- a/tests/test_helpers/test_dependency_tree.py
+++ b/tests/test_helpers/test_dependency_tree.py
@@ -25,14 +25,14 @@ import pytest
 
 from aea.configurations.data_types import PackageId, PackageType, PublicId
 from aea.exceptions import AEAPackageLoadingError
-from aea.helpers.dependency_tree import DependecyTree
+from aea.helpers.dependency_tree import DependencyTree
 
 from tests.conftest import PACKAGES_DIR
 
 
 def test_generation_of_dependency_tree_of_repo_packages() -> None:
     """Test we can generate the dependency tree of the package directory of the repository."""
-    dependency_tree = DependecyTree.generate(Path(PACKAGES_DIR))
+    dependency_tree = DependencyTree.generate(Path(PACKAGES_DIR))
     assert len(dependency_tree) > 0
 
 
@@ -49,7 +49,7 @@ def test_case_when_dependency_tree_has_a_self_loop() -> None:
             f"Found a self-loop dependency while resolving dependency tree in package {dummy_package_id}"
         ),
     ):
-        DependecyTree.resolve_tree(dependency_list)
+        DependencyTree.resolve_tree(dependency_list)
 
 
 def test_case_when_dependency_tree_has_a_cycle() -> None:
@@ -75,4 +75,4 @@ def test_case_when_dependency_tree_has_a_cycle() -> None:
             f"Found a circular dependency while resolving dependency tree: {package_a_id} -> {package_b_id} -> {package_c_id} -> {package_a_id}"
         ),
     ):
-        DependecyTree.resolve_tree(dependency_list)
+        DependencyTree.resolve_tree(dependency_list)

--- a/tests/test_helpers/test_dependency_tree.py
+++ b/tests/test_helpers/test_dependency_tree.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2022 Valory AG
+#   Copyright 2018-2021 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""This module contains the tests for the helper module 'dependency_tree'."""
+import re
+from pathlib import Path
+
+import pytest
+
+from aea.configurations.data_types import PackageId, PackageType, PublicId
+from aea.exceptions import AEAPackageLoadingError
+from aea.helpers.dependency_tree import DependecyTree
+
+from tests.conftest import PACKAGES_DIR
+
+
+def test_generation_of_dependency_tree_of_repo_packages() -> None:
+    """Test we can generate the dependency tree of the package directory of the repository."""
+    dependency_tree = DependecyTree.generate(Path(PACKAGES_DIR))
+    assert len(dependency_tree) > 0
+
+
+def test_case_when_dependency_tree_has_a_self_loop() -> None:
+    """Test we raise error when dependency tree has a node with a self-loop."""
+    dummy_package_id = PackageId(
+        PackageType.PROTOCOL, PublicId.from_str("author/pkg_name:0.1.0")
+    )
+    # self-loop: dummy_package -> dummy_package
+    dependency_list = {dummy_package_id: [dummy_package_id]}
+    with pytest.raises(
+        AEAPackageLoadingError,
+        match=re.escape(
+            f"Found a self-loop dependency while resolving dependency tree in package {dummy_package_id}"
+        ),
+    ):
+        DependecyTree.resolve_tree(dependency_list)
+
+
+def test_case_when_dependency_tree_has_a_cycle() -> None:
+    """Test we raise error when dependency tree has a cycle (length > 1)."""
+    package_a_id = PackageId(
+        PackageType.PROTOCOL, PublicId.from_str("author/pkg_a:0.1.0")
+    )
+    package_b_id = PackageId(
+        PackageType.PROTOCOL, PublicId.from_str("author/pkg_b:0.1.0")
+    )
+    package_c_id = PackageId(
+        PackageType.PROTOCOL, PublicId.from_str("author/pkg_c:0.1.0")
+    )
+    # cycle: package_a -> package_b -> package_c -> package_a
+    dependency_list = {
+        package_a_id: [package_b_id],
+        package_b_id: [package_c_id],
+        package_c_id: [package_a_id],
+    }
+    with pytest.raises(
+        AEAPackageLoadingError,
+        match=re.escape(
+            f"Found a circular dependency while resolving dependency tree: {package_a_id} -> {package_b_id} -> {package_c_id} -> {package_a_id}"
+        ),
+    ):
+        DependecyTree.resolve_tree(dependency_list)


### PR DESCRIPTION
## Proposed changes

Fix #252 by providing a useful error message when a circular dependency is detected while resolving the dependency tree.

Copy-pasting commit message from 357430a as it provides a good summary:


> This commit includes the following improvements to the DependencyTree.resolve_tree method,
while trying not to detour too much from the old structure:
> - split the method in two methods: one is the entry point to the recursive procedure
  (DependencyTree.resolve_tree), and the other is an auxiliary method used by the
  entry point which implements the actual recursive procedure.
> - The entry point, from the client code perspective, is now a pure function:
  given an adjacency list of the dependency graph, return the same graph
  in the form of a nested dictionary.
> - modified the recursive method by doing only one recursive step per method call,
  rather than two steps as it was before this commit. This change gives better
  code structure and readability.
> - in case of a circular dependency, detect the cycle and print a useful error message.
  In case the cycle is actually a self-loop, specify it in the error message;
  Otherwise, print the entire chain that witnesses the circular dependency.
> - Improved docstrings and type hinting.

## Fixes

Fix #252

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes and CI passes too
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a