### PR TITLE
fix: suppress gas estimation on `buildTransaction()`

### DIFF
--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -1408,6 +1408,7 @@ class EthereumApi(LedgerApi, EthereumHelper):
         tx_params = {
             "nonce": nonce,
             "value": tx_args["value"] if "value" in tx_args else 0,
+            "gas": 1,  # set this as a placeholder to avoid estimation on buildTransaction()
         }
 
         # Parameter camel-casing due to contract api requirements
@@ -1431,6 +1432,7 @@ class EthereumApi(LedgerApi, EthereumHelper):
             if gas_data:
                 tx_params.update(gas_data)  # pragma: nocover
         tx = tx.buildTransaction(tx_params)
+        tx = self.update_with_gas_estimate(tx)
         return tx
 
     def get_transaction_transfer_logs(  # pylint: disable=too-many-arguments,too-many-locals

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -1431,8 +1431,11 @@ class EthereumApi(LedgerApi, EthereumHelper):
             )
             if gas_data:
                 tx_params.update(gas_data)  # pragma: nocover
+
         tx = tx.buildTransaction(tx_params)
-        tx = self.update_with_gas_estimate(tx)
+        if self._is_gas_estimation_enabled:
+            tx = self.update_with_gas_estimate(tx)
+
         return tx
 
     def get_transaction_transfer_logs(  # pylint: disable=too-many-arguments,too-many-locals


### PR DESCRIPTION
## Fixes

When `buildTransaction(tx_params)` is called, if `tx_params` doesn't have "gas" set then `buildTransaction()` estimates gas. This can be problematic, especially when repricing txs. To avoid that, we simply add a placeholder gas value of 1.   
