### PR TITLE
Add support for `dict` overrides

### DIFF
--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -1606,19 +1606,21 @@ class AgentConfig(PackageConfiguration):
         for component_id, obj in new_component_configurations.items():
             if component_id not in updated_component_configurations:
                 updated_component_configurations[component_id] = obj
-            elif dict_overrides is not None and component_id in dict_overrides:
-                perform_dict_override(
-                    component_id,
-                    dict_overrides,
-                    updated_component_configurations,
-                    new_component_configurations,
-                )
+
             else:
                 recursive_update(
                     updated_component_configurations[component_id],
                     obj,
                     allow_new_values=True,
                 )
+
+            # if dict_overrides is not None and component_id in dict_overrides:
+            #     perform_dict_override(
+            #         component_id,
+            #         dict_overrides,
+            #         updated_component_configurations,
+            #         new_component_configurations,
+            #     )
 
         self.check_overrides_valid(data, env_vars_friendly=env_vars_friendly)
         super().update(data, env_vars_friendly=env_vars_friendly)

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -1614,13 +1614,13 @@ class AgentConfig(PackageConfiguration):
                     allow_new_values=True,
                 )
 
-            # if dict_overrides is not None and component_id in dict_overrides:
-            #     perform_dict_override(
-            #         component_id,
-            #         dict_overrides,
-            #         updated_component_configurations,
-            #         new_component_configurations,
-            #     )
+            if dict_overrides is not None and component_id in dict_overrides:
+                perform_dict_override(
+                    component_id,
+                    dict_overrides,
+                    updated_component_configurations,
+                    new_component_configurations,
+                )
 
         self.check_overrides_valid(data, env_vars_friendly=env_vars_friendly)
         super().update(data, env_vars_friendly=env_vars_friendly)

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -81,6 +81,7 @@ from aea.helpers.base import (
     SimpleId,
     SimpleIdOrStr,
     load_module,
+    perform_dict_override,
     recursive_update,
 )
 from aea.helpers.ipfs.base import IPFSHashOnly
@@ -1580,7 +1581,12 @@ class AgentConfig(PackageConfiguration):
 
         return result
 
-    def update(self, data: Dict, env_vars_friendly: bool = False) -> None:
+    def update(  # pylint: disable=arguments-differ
+        self,
+        data: Dict,
+        env_vars_friendly: bool = False,
+        dict_overrides: Optional[Dict] = None,
+    ) -> None:
         """
         Update configuration with other data.
 
@@ -1589,6 +1595,7 @@ class AgentConfig(PackageConfiguration):
 
         :param data: the data to replace.
         :param env_vars_friendly: whether or not it is env vars friendly.
+        :param dict_overrides: A dictionary containing mapping for Component ID -> List of paths
         """
         data = copy(data)
         # update component parts
@@ -1599,6 +1606,13 @@ class AgentConfig(PackageConfiguration):
         for component_id, obj in new_component_configurations.items():
             if component_id not in updated_component_configurations:
                 updated_component_configurations[component_id] = obj
+            elif dict_overrides is not None and component_id in dict_overrides:
+                perform_dict_override(
+                    component_id,
+                    dict_overrides,
+                    updated_component_configurations,
+                    new_component_configurations,
+                )
             else:
                 recursive_update(
                     updated_component_configurations[component_id],

--- a/aea/configurations/manager.py
+++ b/aea/configurations/manager.py
@@ -244,7 +244,9 @@ def handle_dotted_path(
         )
 
         # find path to the resource directory
-        path_to_resource_directory = Path(".") / resource_type_plural / resource_name
+        path_to_resource_directory = (
+            aea_project_path / resource_type_plural / resource_name
+        )
         path_to_resource_configuration = (
             path_to_resource_directory
             / RESOURCE_TYPE_TO_CONFIG_FILE[resource_type_plural]

--- a/aea/configurations/manager.py
+++ b/aea/configurations/manager.py
@@ -20,6 +20,7 @@
 """Implementation of the AgentConfigManager."""
 import json
 import os
+from collections import OrderedDict
 from copy import deepcopy
 from pathlib import Path
 from typing import Callable, Dict, List, NewType, Optional, Set, Tuple, Union, cast
@@ -383,7 +384,15 @@ class AgentConfigManager:
             # agent
             overrides.update(data)
 
-        self.update_config(overrides)
+        dict_overrides: Optional[Dict] = None
+        if isinstance(value, (dict, OrderedDict)):
+            dict_overrides = {
+                component_id: [
+                    json_path,
+                ]
+            }
+
+        self.update_config(overrides, dict_overrides=dict_overrides)
 
     @staticmethod
     def _make_dict_for_path_and_value(json_path: JsonPath, value: JSON_TYPES) -> Dict:
@@ -486,7 +495,11 @@ class AgentConfigManager:
             )
         return component_id, json_path
 
-    def update_config(self, overrides: Dict) -> None:
+    def update_config(
+        self,
+        overrides: Dict,
+        dict_overrides: Optional[Dict] = None,
+    ) -> None:
         """
         Apply overrides for agent config.
 
@@ -494,6 +507,7 @@ class AgentConfigManager:
         Does not save it on the disc!
 
         :param overrides: overridden values dictionary
+        :param dict_overrides: A dictionary containing mapping for Component ID -> List of paths
 
         :return: None
         """
@@ -512,7 +526,11 @@ class AgentConfigManager:
                 obj, env_vars_friendly=self.env_vars_friendly
             )
 
-        self.agent_config.update(overrides, env_vars_friendly=self.env_vars_friendly)
+        self.agent_config.update(
+            overrides,
+            env_vars_friendly=self.env_vars_friendly,
+            dict_overrides=dict_overrides,
+        )
 
     def _filter_overrides(self, overrides: Dict) -> Dict:
         """Stay only updated values for agent config."""

--- a/aea/configurations/validation.py
+++ b/aea/configurations/validation.py
@@ -310,21 +310,23 @@ def validate_data_with_pattern(
                 return True
         return False
 
+    def is_a_dict_override(path: Tuple[str, ...]) -> bool:
+        """Check if an override is a dict override."""
+        flag = False
+        while len(path) > 0:
+            path = path[:-1]
+            if path in pattern_path_value:
+                pattern_value = pattern_path_value[path]
+                flag = isinstance(pattern_value, OrderedDict)
+                break
+        return flag
+
     for path, new_value in data_path_value.items():
         if check_excludes(path):
             continue
 
         if path not in pattern_path_value:
-            is_a_dict_override = False
-            path_ = deepcopy(path)
-            while len(path_) > 0:
-                path_ = path_[:-1]
-                if path_ not in pattern_path_value:
-                    continue
-                pattern_value = pattern_path_value[path_]
-                is_a_dict_override = isinstance(pattern_value, OrderedDict)
-
-            if not is_a_dict_override:
+            if not is_a_dict_override(path=(*path,)):
                 errors.append(
                     f"Attribute `{'.'.join(path)}` is not allowed to be updated!"
                 )

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -485,6 +485,33 @@ def recursive_update(
             to_update[key] = value
 
 
+def perform_dict_override(
+    component_id: Any,
+    overrides: Dict,
+    updated_configuration: Dict,
+    new_configuration: Dict,
+) -> None:
+    """
+    Perform recursive dict override.
+
+    :param component_id: Component ID for which the updated will be performed
+    :param overrides: A dictionary containing mapping for Component ID -> List of paths
+    :param updated_configuration: Configuration which needs to be updated
+    :param new_configuration: Configuration from which the method will perform the update
+    """
+    for path in overrides[component_id]:
+
+        will_be_updated = updated_configuration[component_id]
+        update = new_configuration[component_id]
+
+        *params, update_param = path
+        for param in params:
+            will_be_updated = will_be_updated[param]
+            update = update[param]
+
+        will_be_updated[update_param] = update[update_param]
+
+
 def _get_aea_logger_name_prefix(module_name: str, agent_name: str) -> str:
     """
     Get the logger name prefix.

--- a/docs/api/configurations/manager.md
+++ b/docs/api/configurations/manager.md
@@ -173,7 +173,8 @@ json friendly value.
 #### update`_`config
 
 ```python
-def update_config(overrides: Dict) -> None
+def update_config(overrides: Dict,
+                  dict_overrides: Optional[Dict] = None) -> None
 ```
 
 Apply overrides for agent config.
@@ -184,6 +185,7 @@ Does not save it on the disc!
 **Arguments**:
 
 - `overrides`: overridden values dictionary
+- `dict_overrides`: A dictionary containing mapping for Component ID -> List of paths
 
 **Returns**:
 

--- a/docs/api/helpers/base.md
+++ b/docs/api/helpers/base.md
@@ -342,6 +342,25 @@ It does side-effects to the first dictionary.
 - `new_values`: the dictionary of new values to replace.
 - `allow_new_values`: whether or not to allow new values.
 
+<a id="aea.helpers.base.perform_dict_override"></a>
+
+#### perform`_`dict`_`override
+
+```python
+def perform_dict_override(component_id: Any, overrides: Dict,
+                          updated_configuration: Dict,
+                          new_configuration: Dict) -> None
+```
+
+Perform recursive dict override.
+
+**Arguments**:
+
+- `component_id`: Component ID for which the updated will be performed
+- `overrides`: A dictionary containing mapping for Component ID -> List of paths
+- `updated_configuration`: Configuration which needs to be updated
+- `new_configuration`: Configuration from which the method will perform the update
+
 <a id="aea.helpers.base.find_topological_order"></a>
 
 #### find`_`topological`_`order

--- a/tests/data/dummy_aea/aea-config.yaml
+++ b/tests/data/dummy_aea/aea-config.yaml
@@ -37,3 +37,10 @@ connection_private_key_paths:
   fetchai: fetchai_private_key.txt
 default_routing: {}
 dependencies: {}
+---
+public_id: dummy_author/test_skill:0.1.0
+type: skill
+models:
+  scaffold:
+    args:
+      recursive: {}

--- a/tests/data/dummy_aea/skills/test_skill/skill.yaml
+++ b/tests/data/dummy_aea/skills/test_skill/skill.yaml
@@ -30,6 +30,7 @@ models:
   scaffold:
     args:
       foo: bar
+      recursive: {}
     class_name: MyModel
 dependencies: {}
 is_abstract: false

--- a/tests/test_aea_builder.py
+++ b/tests/test_aea_builder.py
@@ -1052,9 +1052,7 @@ def test_dependency_tree_check():
     dummy_aea_path = Path(CUR_PATH, "data", "dummy_aea")
     aea_config_file = dummy_aea_path / DEFAULT_AEA_CONFIG_FILE
     original_content = aea_config_file.read_text()
-    missing_dependencies = original_content.replace(
-        "- dummy_author/dummy:0.1.0\n", ""
-    )
+    missing_dependencies = original_content.replace("- dummy_author/dummy:0.1.0\n", "")
     aea_config_file.write_text(missing_dependencies)
 
     try:

--- a/tests/test_aea_builder.py
+++ b/tests/test_aea_builder.py
@@ -1053,7 +1053,7 @@ def test_dependency_tree_check():
     aea_config_file = dummy_aea_path / DEFAULT_AEA_CONFIG_FILE
     original_content = aea_config_file.read_text()
     missing_dependencies = original_content.replace(
-        "- dummy_author/test_skill:0.1.0\n", ""
+        "- dummy_author/dummy:0.1.0\n", ""
     )
     aea_config_file.write_text(missing_dependencies)
 
@@ -1061,7 +1061,7 @@ def test_dependency_tree_check():
         with pytest.raises(
             AEAEnforceError,
             match=re.escape(
-                "Following dependencies are present in the project but missing from the aea-config.yaml; {PackageId(skill, dummy_author/test_skill:0.1.0)}"
+                "Following dependencies are present in the project but missing from the aea-config.yaml; {PackageId(skill, dummy_author/dummy:0.1.0)}"
             ),
         ):
             AEABuilder.from_aea_project(dummy_aea_path)

--- a/tests/test_cli/test_config.py
+++ b/tests/test_cli/test_config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021 Valory AG
+#   Copyright 2021-2022 Valory AG
 #   Copyright 2018-2019 Fetch.AI Limited
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_cli/test_config.py
+++ b/tests/test_cli/test_config.py
@@ -676,8 +676,6 @@ class TestConfigNestedGetSet:
     def test_set_get_correct_path(self):
         """Test component value updated in agent config not in component config."""
         agent_config = self.load_agent_config()
-        assert not agent_config.component_configurations
-
         config_value = self.get_component_config_value()
         assert config_value == self.INITIAL_VALUE
 

--- a/tests/test_configurations/test_base.py
+++ b/tests/test_configurations/test_base.py
@@ -366,7 +366,7 @@ class TestAgentConfigUpdate:
 
     def test_component_configurations_setter(self):
         """Test component configuration setter."""
-        assert self.aea_config.component_configurations == {}
+        assert len(self.aea_config.component_configurations) == 1
         new_component_configurations = {
             self.dummy_skill_component_id: self.new_dummy_skill_config
         }
@@ -374,7 +374,7 @@ class TestAgentConfigUpdate:
 
     def test_component_configurations_setter_negative(self):
         """Test component configuration setter with wrong configurations."""
-        assert self.aea_config.component_configurations == {}
+        assert len(self.aea_config.component_configurations) == 1
         new_component_configurations = {
             self.dummy_skill_component_id: {
                 "handlers": {"dummy": {"class_name": "SomeClass"}}

--- a/tests/test_configurations/test_manager.py
+++ b/tests/test_configurations/test_manager.py
@@ -271,7 +271,20 @@ def test_recursive_updates() -> None:
         ),
     )
 
-    assert value == {"foo": "bar", "hello": "world"}
+    assert value == {"hello": "world"}
+
+    agent_config_manager.set_variable(
+        "skills.test_skill.models.scaffold.args.recursive.hello",
+        "world_0",
+    )
+    value = cast(
+        Dict,
+        agent_config_manager.get_variable(
+            "skills.test_skill.models.scaffold.args.recursive"
+        ),
+    )
+
+    assert value == {"hello": "world_0"}
 
 
 def test_agent_attribute_get_overridables():

--- a/tests/test_configurations/test_manager.py
+++ b/tests/test_configurations/test_manager.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021 Valory AG
+#   Copyright 2021-2022 Valory AG
 #   Copyright 2018-2019 Fetch.AI Limited
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -262,7 +262,7 @@ def test_recursive_updates() -> None:
 
     agent_config_manager.set_variable(
         "skills.test_skill.models.scaffold.args.recursive",
-        {"foo": "bar", "hello": "world"},
+        {"hello": "world"},
     )
     value = cast(
         Dict,


### PR DESCRIPTION
## Proposed changes

This PR updates the config manager and override validator to support dict overrides

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules