### PR TITLE
Add nested params variable on base config class

### DIFF
--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -225,7 +225,11 @@ class PackageConfiguration(Configuration, ABC):
 
     default_configuration_filename: str
     package_type: PackageType
+
     FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset(["build_directory"])
+    FIELDS_WITH_NESTED_FIELDS: FrozenSet[str] = frozenset()
+    NESTED_FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset()
+
     schema: str
     CHECK_EXCLUDES: List[Tuple[str]] = []
 
@@ -572,6 +576,7 @@ class ConnectionConfig(ComponentConfiguration):
     FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset(
         ["config", "cert_requests", "is_abstract", "build_directory"]
     )
+    FIELDS_WITH_NESTED_FIELDS: FrozenSet[str] = frozenset(["config"])
 
     __slots__ = (
         "class_name",

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -228,7 +228,6 @@ class PackageConfiguration(Configuration, ABC):
     package_type: PackageType
 
     FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset(["build_directory"])
-    FIELDS_WITH_NESTED_FIELDS: FrozenSet[str] = frozenset()
 
     schema: str
     CHECK_EXCLUDES: List[Tuple[str]] = []
@@ -576,7 +575,6 @@ class ConnectionConfig(ComponentConfiguration):
     FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset(
         ["config", "cert_requests", "is_abstract", "build_directory"]
     )
-    FIELDS_WITH_NESTED_FIELDS: FrozenSet[str] = frozenset(["config"])
 
     __slots__ = (
         "class_name",
@@ -958,9 +956,6 @@ class SkillConfig(ComponentConfiguration):
     FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset(
         ["behaviours", "handlers", "models", "is_abstract", "build_directory"]
     )
-    FIELDS_WITH_NESTED_FIELDS: FrozenSet[str] = frozenset(
-        ["behaviours", "handlers", "models"]
-    )
 
     __slots__ = (
         "connections",
@@ -1136,20 +1131,6 @@ class SkillConfig(ComponentConfiguration):
             instance.models.create(model_id, model_config)
 
         return instance
-
-    def get_overridable(self) -> dict:
-        """Get overridable configuration data."""
-        result = {}
-        current_config_data = self.json
-        if self.abstract_field_name in current_config_data:
-            result[self.abstract_field_name] = current_config_data[
-                self.abstract_field_name
-            ]
-        for field in self.FIELDS_WITH_NESTED_FIELDS:
-            if not current_config_data.get(field, {}):
-                continue
-            result[field] = current_config_data[field]
-        return result
 
 
 class AgentConfig(PackageConfiguration):

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -229,7 +229,6 @@ class PackageConfiguration(Configuration, ABC):
 
     FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset(["build_directory"])
     FIELDS_WITH_NESTED_FIELDS: FrozenSet[str] = frozenset()
-    NESTED_FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset()
 
     schema: str
     CHECK_EXCLUDES: List[Tuple[str]] = []
@@ -962,7 +961,6 @@ class SkillConfig(ComponentConfiguration):
     FIELDS_WITH_NESTED_FIELDS: FrozenSet[str] = frozenset(
         ["behaviours", "handlers", "models"]
     )
-    NESTED_FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset(["args"])
 
     __slots__ = (
         "connections",
@@ -1147,17 +1145,10 @@ class SkillConfig(ComponentConfiguration):
             result[self.abstract_field_name] = current_config_data[
                 self.abstract_field_name
             ]
-
         for field in self.FIELDS_WITH_NESTED_FIELDS:
             if not current_config_data.get(field, {}):
                 continue
-            result[field] = {}
-            for name in current_config_data[field].keys():
-                result[field][name] = {}
-                for nested_field in self.NESTED_FIELDS_ALLOWED_TO_UPDATE:
-                    result[field][name][nested_field] = current_config_data[field][
-                        name
-                    ][nested_field]
+            result[field] = current_config_data[field]
         return result
 
 

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -951,7 +951,6 @@ class SkillConfig(ComponentConfiguration):
     default_configuration_filename = DEFAULT_SKILL_CONFIG_FILE
     package_type = PackageType.SKILL
     schema = "skill-config_schema.json"
-    abstract_field_name = "is_abstract"
 
     FIELDS_ALLOWED_TO_UPDATE: FrozenSet[str] = frozenset(
         ["behaviours", "handlers", "models", "is_abstract", "build_directory"]

--- a/aea/test_tools/generic.py
+++ b/aea/test_tools/generic.py
@@ -117,10 +117,7 @@ def _nested_set(
         return _dic
 
     root_key = keys[0]
-    if (
-        isinstance(configuration_obj, SkillConfig)
-        and root_key in SkillConfig.FIELDS_WITH_NESTED_FIELDS
-    ):
+    if isinstance(configuration_obj, SkillConfig):
         root_attr = getattr(configuration_obj, root_key)
         length = len(keys)
         if length < 3:

--- a/aea/test_tools/generic.py
+++ b/aea/test_tools/generic.py
@@ -123,7 +123,7 @@ def _nested_set(
     ):
         root_attr = getattr(configuration_obj, root_key)
         length = len(keys)
-        if length < 3 or keys[2] not in SkillConfig.NESTED_FIELDS_ALLOWED_TO_UPDATE:
+        if length < 3:
             raise ValueError(f"Invalid keys={keys}.")  # pragma: nocover
         skill_component_id = keys[1]
         skill_component_config = root_attr.read(skill_component_id)

--- a/aea/test_tools/generic.py
+++ b/aea/test_tools/generic.py
@@ -117,10 +117,13 @@ def _nested_set(
         return _dic
 
     root_key = keys[0]
-    if isinstance(configuration_obj, SkillConfig):
+    if (
+        isinstance(configuration_obj, SkillConfig)
+        and root_key in SkillConfig.FIELDS_WITH_NESTED_FIELDS
+    ):
         root_attr = getattr(configuration_obj, root_key)
         length = len(keys)
-        if length < 3:
+        if length < 3 or keys[2] not in SkillConfig.NESTED_FIELDS_ALLOWED_TO_UPDATE:
             raise ValueError(f"Invalid keys={keys}.")  # pragma: nocover
         skill_component_id = keys[1]
         skill_component_config = root_attr.read(skill_component_id)


### PR DESCRIPTION
## Proposed changes

This PR adds `FIELDS_WITH_NESTED_FIELDS` and `NESTED_FIELDS_ALLOWED_TO_UPDATE` in the base config class

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

