### PR TITLE
Set local as default registry and IPFS as default remote registry

### DIFF
--- a/aea/cli/init.py
+++ b/aea/cli/init.py
@@ -49,8 +49,8 @@ from aea.cli.utils.package_utils import validate_author_name
 @click.option("--author", type=str, required=False)
 @click.option("--reset", is_flag=True, help="To reset the initialization.")
 @click.option("--no-subscribe", is_flag=True, help="For developers subscription.")
-@registry_flag(mark_default=True)
-@remote_registry_flag(mark_default=True)
+@registry_flag(mark_default=True, default_registry=REGISTRY_LOCAL)
+@remote_registry_flag(mark_default=True, default_registry=REMOTE_IPFS)
 @click.option(
     "--ipfs-node", type=str, default=DEFAULT_IPFS_URL, help="Multiaddr for IPFS node."
 )

--- a/aea/cli/init.py
+++ b/aea/cli/init.py
@@ -42,19 +42,15 @@ from aea.cli.utils.config import get_or_create_cli_config, update_cli_config
 from aea.cli.utils.constants import AEA_LOGO, AUTHOR_KEY
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import pass_ctx
-from aea.cli.utils.package_utils import (
-    validate_author_name,
-    validate_registry_type,
-    validate_remote_registry_type,
-)
+from aea.cli.utils.package_utils import validate_author_name
 
 
 @click.command()
 @click.option("--author", type=str, required=False)
 @click.option("--reset", is_flag=True, help="To reset the initialization.")
 @click.option("--no-subscribe", is_flag=True, help="For developers subscription.")
-@registry_flag(mark_default=False)
-@remote_registry_flag(mark_default=False)
+@registry_flag(mark_default=True)
+@remote_registry_flag(mark_default=True)
 @click.option(
     "--ipfs-node", type=str, default=DEFAULT_IPFS_URL, help="Multiaddr for IPFS node."
 )
@@ -64,8 +60,8 @@ def init(  # pylint: disable=unused-argument
     author: str,
     reset: bool,
     no_subscribe: bool,
-    registry: Optional[str],
-    remote_registry: Optional[str],
+    registry: str,
+    remote_registry: str,
     ipfs_node: Optional[str],
 ) -> None:
     """Initialize your AEA configurations."""
@@ -83,8 +79,8 @@ def do_init(
     author: str,
     reset: bool,
     no_subscribe: bool,
-    registry_type: Optional[str] = None,
-    default_remote_registry: Optional[str] = None,
+    registry_type: str = REGISTRY_LOCAL,
+    default_remote_registry: str = REMOTE_IPFS,
     ipfs_node: Optional[str] = None,
 ) -> None:
     """
@@ -100,17 +96,11 @@ def do_init(
     config = get_or_create_cli_config()
     if reset or config.get(AUTHOR_KEY, None) is None:
         author = validate_author_name(author)
-        registry_type = validate_registry_type(registry_type)
         update_cli_config({AUTHOR_KEY: author})
 
         if registry_type == REGISTRY_LOCAL:
-            if default_remote_registry is None:
-                default_remote_registry = REMOTE_IPFS
             _registry_init_local(default_remote_registry)
         else:
-            default_remote_registry = validate_remote_registry_type(
-                default_remote_registry
-            )
             _registry_init_remote(
                 default_remote_registry, author, no_subscribe, ipfs_node
             )

--- a/aea/cli/utils/click_utils.py
+++ b/aea/cli/utils/click_utils.py
@@ -222,15 +222,17 @@ class AgentDirectory(click.Path):
             os.chdir(cwd)
 
 
-def registry_flag(mark_default: bool = True) -> Callable:
+def registry_flag(
+    mark_default: bool = True,
+    default_registry: str = REGISTRY_LOCAL,
+) -> Callable:
     """Choice of one flag between: '--local/--remote'."""
 
-    default_registry: Optional[str] = (
+    default_registry = default_registry or (
         get_or_create_cli_config().get("registry_config", {}).get("default")
     )
 
-    if default_registry is None:
-        default_registry = REGISTRY_LOCAL
+    default_registry = default_registry or REGISTRY_LOCAL
 
     def wrapper(f: Callable) -> Callable:
         f = option(
@@ -252,10 +254,13 @@ def registry_flag(mark_default: bool = True) -> Callable:
     return wrapper
 
 
-def remote_registry_flag(mark_default: bool = True) -> Callable:
+def remote_registry_flag(
+    mark_default: bool = True,
+    default_registry: str = REMOTE_IPFS,
+) -> Callable:
     """Choice of one flag between: '--ipfs/--http'."""
 
-    default_registry: Optional[str] = (
+    default_registry = default_registry or (
         get_or_create_cli_config()
         .get("registry_config", {})
         .get("settings", {})
@@ -263,8 +268,7 @@ def remote_registry_flag(mark_default: bool = True) -> Callable:
         .get("default")
     )
 
-    if default_registry is None:
-        default_registry = REMOTE_IPFS
+    default_registry = default_registry or REMOTE_IPFS
 
     def wrapper(f: Callable) -> Callable:
         f = option(

--- a/aea/cli/utils/click_utils.py
+++ b/aea/cli/utils/click_utils.py
@@ -224,7 +224,7 @@ class AgentDirectory(click.Path):
 
 def registry_flag(
     mark_default: bool = True,
-    default_registry: str = REGISTRY_LOCAL,
+    default_registry: Optional[str] = None,
 ) -> Callable:
     """Choice of one flag between: '--local/--remote'."""
 
@@ -256,7 +256,7 @@ def registry_flag(
 
 def remote_registry_flag(
     mark_default: bool = True,
-    default_registry: str = REMOTE_IPFS,
+    default_registry: Optional[str] = None,
 ) -> Callable:
     """Choice of one flag between: '--ipfs/--http'."""
 

--- a/aea/cli/utils/package_utils.py
+++ b/aea/cli/utils/package_utils.py
@@ -29,12 +29,6 @@ from jsonschema import ValidationError
 
 from aea import AEA_DIR, get_current_aea_version
 from aea.cli.fingerprint import fingerprint_item
-from aea.cli.registry.settings import (
-    REGISTRY_LOCAL,
-    REGISTRY_TYPES,
-    REMOTE_HTTP,
-    REMOTE_IPFS,
-)
 from aea.cli.utils.config import (
     dump_item_config,
     get_non_vendor_package_path,
@@ -465,46 +459,6 @@ def validate_author_name(author: Optional[str] = None) -> str:
             )
 
     return valid_author
-
-
-def validate_registry_type(default_registry: Optional[str] = None) -> str:
-    """
-    Validate registry type.
-
-    :param default_registry: registry type (optional)
-    :return: validated registry name
-    """
-    if default_registry is None:
-        default_registry = click.prompt(
-            text="Please select default registry type",
-            type=click.Choice(REGISTRY_TYPES, case_sensitive=True),
-            show_choices=True,
-            default=REGISTRY_LOCAL,
-        )
-    if default_registry not in REGISTRY_TYPES:
-        raise ValueError(f"Default registry type should be one of {REGISTRY_TYPES}")
-    return default_registry
-
-
-def validate_remote_registry_type(remote_registry: Optional[str] = None) -> str:
-    """
-    Validate registry type.
-
-    :param remote_registry: registry type (optional)
-    :return: validated registry name
-    """
-    if remote_registry is None:
-        remote_registry = click.prompt(
-            text="Please select the type of remote registry to use",
-            type=click.Choice((REMOTE_HTTP, REMOTE_IPFS), case_sensitive=True),
-            show_choices=True,
-            default=REMOTE_HTTP,
-        )
-    if remote_registry not in (REMOTE_HTTP, REMOTE_IPFS):
-        raise ValueError(
-            f"Default registry type should be one of {(REMOTE_HTTP, REMOTE_IPFS)}"
-        )
-    return remote_registry
 
 
 def is_fingerprint_correct(


### PR DESCRIPTION
## Proposed changes

This PR updates the `init` command to set local as default registry and IPFS as default remote registry if no user options provided 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules


