### PR TITLE
V1.18.0.post2

### DIFF
--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.18.0.post1"
+__version__ = "1.18.0.post2"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/aea/cli/test.py
+++ b/aea/cli/test.py
@@ -382,9 +382,9 @@ def test_package_collection(
 
     for package_type, package_dir in available_packages:
         test_dir = package_dir / AEA_TEST_DIRNAME
-        if package_type == PackageType.AGENT.value or not test_dir.exists():
+        if not test_dir.exists():
             continue
-
+        
         load_package(package_dir, packages_dir=packages_dir)
         with cd(package_dir):
             click.echo(f"Running tests for {package_dir.name} of type {package_type}")

--- a/aea/cli/test.py
+++ b/aea/cli/test.py
@@ -384,7 +384,7 @@ def test_package_collection(
         test_dir = package_dir / AEA_TEST_DIRNAME
         if not test_dir.exists():
             continue
-        
+
         load_package(package_dir, packages_dir=packages_dir)
         with cd(package_dir):
             click.echo(f"Running tests for {package_dir.name} of type {package_type}")

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.18.0.post1 "open-aea-cli-ipfs<2.0.0,>=1.18.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.18.0.post2 "open-aea-cli-ipfs<2.0.0,>=1.18.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.18.0.post1/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.18.0.post2/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.18.0.post1
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.18.0.post2
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.18.0.post1
+RUN pip install --upgrade --force-reinstall aea[all]==1.18.0.post2
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.18.0.post1 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.18.0.post2 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.18.0.post1 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.18.0.post2 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.18.0.post1"
+      template: "1.18.0.post2"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.18.0.post1"
+          template: "1.18.0.post2"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -44,7 +44,7 @@ pip install open-aea[all]
 pip install open-aea-cli-ipfs
 ```
 ```
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.18.0.post1/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.18.0.post2/packages packages
 ```
 
 ``` bash

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.18.0.post1
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.18.0.post2
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.18.0.post2

## Release details

- Enables running tests while running tests for a package collection

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [ ] Lint and unit tests pass locally and in CI
- [ ] I have checked the fingerprint hashes are correct by running (`aea hash all --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

## Further comments

Write here any other comment about the release, if any.