### PR TITLE
fix: add check on author for 'aea check-packages'

### DIFF
--- a/tests/test_check_packages.py
+++ b/tests/test_check_packages.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2022 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""This module contains the tests for aea/aea.py."""
+from aea.test_tools.test_cases import AEATestCaseEmpty
+
+
+class TestCheckPackages(AEATestCaseEmpty):
+    """Test 'aea check_packages'."""
+
+    def test_run(self) -> None:
+        """Run the test."""
+        result = self.run_cli_command("check-packages", str(self.packages_dir_path))
+        assert result.exit_code == 0


### PR DESCRIPTION
## Proposed changes

The command `aea check-packages` was missing a check on author present in open-autonomy: https://github.com/valory-xyz/open-autonomy/blob/main/scripts/check_packages.py#L316

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a