### PR TITLE
Make sure we don't use the local IPFS node unless explicitly specified

### DIFF
--- a/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
+++ b/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
@@ -36,7 +36,8 @@ from aea_cli_ipfs.exceptions import (
 )
 
 
-DEFAULT_IPFS_URL = "/ip4/127.0.0.1/tcp/5001"
+DEFAULT_IPFS_URL = "/dns/registry.autonolas.tech/tcp/443/https"
+DEFAULT_IPFS_URL_LOCAL = "/ip4/127.0.0.1/tcp/5001"
 ALLOWED_CONNECTION_TYPES = ("tcp",)
 ALLOWED_ADDR_TYPES = ("ip4", "dns")
 ALLOWED_PROTOCOL_TYPES = ("http", "https")


### PR DESCRIPTION
## Proposed changes

This PR update the IPFS plugin to make sure we don't use the local IPFS node unless explicitly specified

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules