### PR TITLE
Release v1.20.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,35 @@
 # Release History - open AEA
 
+## 1.20.0 (2022-09-20)
+
+AEA:
+- Ensures author and year in copyright headers are updated in scaffolded components
+- Updates `check-packages` 
+  - to check the presence of the constant `PUBLIC_ID` for connections and skills.
+  - to validate author
+- Fixes CLI help message for `aea config set` command
+- Extends test command to support consistency check skips and to run tests for a specific author
+- Fixes scaffold tool to update the copyright header with the current year
+- Adds proper exception raising and error handling 
+  - Exception handling when downloading from IPFS nodes
+  - Better error message when the `--aev` flag is not provided
+- Fixes file sorting to maintain consistency of links on `PBNode` object on `IPFSHashOnly` tool
+
+Plugins:
+- Updates the IPFS plugin to make make sure we don't use the local IPFS node unless explicitly specified
+
+Packages:
+- Ports `libp2p` connection packages tests
+  - Ports `p2p_libp2p_client` tests
+  - Ports `p2p_libp2p_client` tests
+  - Ports `p2p_libp2p` tests
+- Introduces `test_libp2p` connection package to test `libp2p` integration
+
+Chores:
+- Fixes docstring formatting to make sure doc generator works fine
+- Updated `check_ipfs_hashes.py` script to use `packages.json` instead of `hashes.csv`
+- Updates the command regex to align with the latest version
+  
 ## 1.19.0 (2022-09-14)
 
 AEA:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,6 @@ AEA:
   - to validate author
 - Fixes CLI help message for `aea config set` command
 - Extends test command to support consistency check skips and to run tests for a specific author
-- Fixes scaffold tool to update the copyright header with the current year
 - Adds proper exception raising and error handling 
   - Exception handling when downloading from IPFS nodes
   - Better error message when the `--aev` flag is not provided
@@ -20,7 +19,7 @@ Plugins:
 
 Packages:
 - Ports `libp2p` connection packages tests
-  - Ports `p2p_libp2p_client` tests
+  - Ports `p2p_libp2p_mailbox` tests
   - Ports `p2p_libp2p_client` tests
   - Ports `p2p_libp2p` tests
 - Introduces `test_libp2p` connection package to test `libp2p` integration

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-aea` are currently being suppo
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `1.19.x`   | :white_check_mark: |
-| `< 1.19.0` | :x:                |
+| `1.20.x`   | :white_check_mark: |
+| `< 1.20.0` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.19.0"
+__version__ = "1.20.0"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.20.0 "open-aea-cli-ipfs<2.0.0,>=1.19.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.20.0 "open-aea-cli-ipfs<2.0.0,>=1.20.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.19.0 "open-aea-cli-ipfs<2.0.0,>=1.19.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.20.0 "open-aea-cli-ipfs<2.0.0,>=1.19.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.19.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.20.0/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.19.0
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.20.0
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,6 +7,14 @@ Below we describe the additional manual steps required to upgrade between differ
 
 # Open AEA
 
+
+## `v1.19.0` to `v1.20.0`
+
+
+No backwards incompatible changes.
+
+Plugins from previous versions are not compatible anymore.
+
 ## `v1.18.0` to `v1.19.0`
 
 - Deprecated the usage of `hashes.csv` and replaces it with `packages.json`, which is maintained by `aea packages lock`

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.19.0
+RUN pip install --upgrade --force-reinstall aea[all]==1.20.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-benchmark",
-    version="1.19.0",
+    version="1.20.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.19.0",
+    version="1.20.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.19.0",
+    version="1.20.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.19.0",
+    version="1.20.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.19.0",
+    version="1.20.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.19.0 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.20.0 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.19.0 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.20.0 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.19.0"
+      template: "1.20.0"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.19.0"
+          template: "1.20.0"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -44,7 +44,7 @@ pip install open-aea[all]
 pip install open-aea-cli-ipfs
 ```
 ```
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.19.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.20.0/packages packages
 ```
 
 ``` bash

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.19.0
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.20.0
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.20.0

## Release details

## 1.20.0 (2022-09-20)

AEA:
- Ensures author and year in copyright headers are updated in scaffolded components
- Updates `check-packages` 
  - to check the presence of the constant `PUBLIC_ID` for connections and skills.
  - to validate author
- Fixes CLI help message for `aea config set` command
- Extends test command to support consistency check skips and to run tests for a specific author
- Fixes scaffold tool to update the copyright header with the current year
- Adds proper exception raising and error handling 
  - Exception handling when downloading from IPFS nodes
  - Better error message when the `--aev` flag is not provided
- Fixes file sorting to maintain consistency of links on `PBNode` object on `IPFSHashOnly` tool

Plugins:
- Updates the IPFS plugin to make make sure we don't use the local IPFS node unless explicitly specified

Packages:
- Ports `libp2p` connection packages tests
  - Ports `p2p_libp2p_client` tests
  - Ports `p2p_libp2p_client` tests
  - Ports `p2p_libp2p` tests
- Introduces `test_libp2p` connection package to test `libp2p` integration

Chores:
- Fixes docstring formatting to make sure doc generator works fine
- Updated `check_ipfs_hashes.py` script to use `packages.json` instead of `hashes.csv`
- Updates the command regex to align with the latest version

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side), from `develop`
- [x] Lint and unit tests pass locally and in CI
- [x] I have checked the fingerprint hashes are correct by running (`aea hash all` and `aea packages lock --check`)
- [x] I have regenerated the latest API docs
- [x] I built the documentation and updated it with the latest changes
- [x] I have added an item in `HISTORY.md` for this release
- [x] I bumped the version number in the `aea/__version__.py` file.
- [x] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

## Further comments

Write here any other comment about the release, if any.
