### PR TITLE
Fix path formatting while serialising `CertRequest` class

### DIFF
--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -953,7 +953,7 @@ class CertRequest:
             not_after=self._not_after_string,
             public_key=self.public_key_or_identifier,
             message_format=self.message_format,
-            save_path=str(self.save_path),
+            save_path=str(self.save_path.as_posix()),
         )
         return result
 

--- a/tests/test_helpers/test_base.py
+++ b/tests/test_helpers/test_base.py
@@ -592,6 +592,23 @@ class TestCertRequestInstantiationWithKeyHex(BaseTestCertRequestInstantiation):
     EXPECTED_KEY_IDENTIFIER = None
 
 
+def test_cert_request_path_dumping() -> None:
+    """Test if the path is being dumped correctly."""
+
+    test_path = ".cert_requests/cert.txt"
+    cert_request = CertRequest(
+        public_key="public_key",
+        identifier="identifier",
+        ledger_id="ledger_id",
+        not_before=NOT_BEFORE,
+        not_after=NOT_AFTER,
+        message_format="{public_key}",
+        save_path=test_path,
+    )
+
+    assert cert_request.json["save_path"] == test_path
+
+
 def test_compute_specifier_from_version():
     """Test function 'compute_specifier_from_version'."""
 


### PR DESCRIPTION
## Proposed changes

This PR update the cert request dumping to make sure we dump paths in posix format

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules