### PR TITLE
fix: add importlib-metadata<5.0.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
     pytest-randomly==3.11.0
     pytest-rerunfailures==10.0
     GitPython==3.1.27
+    importlib-metadata<5.0.0
     ; Plugin dependencies. We need this
     ; because we use --no-deps to install the plugins.
     ; aea_ledger_cosmos/aea_ledger_fetchai


### PR DESCRIPTION
## Proposed changes

Due to new importlib-metadata release:

    https://importlib-metadata.readthedocs.io/en/latest/history.html#v5-0-0

The test execution gives the following error on Python 3.7:

    AttributeError: 'EntryPoints' object has no attribute 'get'

e.g. see https://github.com/valory-xyz/open-aea/actions/runs/3210821379/jobs/5248586339

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a