### PR TITLE
fix: make generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,7 @@ security:
 generators:
 	rm -rf packages/fetchai/connections/stub/input_file
 	tox -e fix-copyright
-	python -m aea.cli hash all
-	python -m aea.cli hash all --packages-dir=./tests/data/packages
+	tox -e hash-all
 	tox -e lock-packages
 	tox -e generate-all-protocols
 	tox -e generate-api-documentation

--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,7 @@ generators:
 	tox -e fix-copyright
 	python -m aea.cli hash all
 	python -m aea.cli hash all --packages-dir=./tests/data/packages
-	python -m aea.cli packages lock
-	python -m aea.cli --registry-path=./tests/data/packages packages lock
+	tox -e lock-packages
 	tox -e generate-all-protocols
 	tox -e generate-api-documentation
 	tox -e fix-doc-hashes

--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,7 @@ generators:
 	python -m aea.cli hash all --packages-dir=./tests/data/packages
 	python -m aea.cli packages lock
 	python -m aea.cli --registry-path=./tests/data/packages packages lock
-	python -m aea.cli generate-all-protocols
-	python -m aea.cli generate-all-protocols tests/data/packages
+	tox -e generate-all-protocols
 	tox -e generate-api-documentation
 	tox -e fix-doc-hashes
 

--- a/tox.ini
+++ b/tox.ini
@@ -194,6 +194,15 @@ commands =
     aea packages lock --check
     aea --registry-path=./tests/data/packages packages lock --check
 
+[testenv:lock-packages]
+skipsdist = True
+usedevelop = True
+commands =
+    pip install {toxinidir}[all]
+    python -m pip install --no-deps file://{toxinidir}/plugins/aea-cli-ipfs
+    aea packages lock
+    aea --registry-path=./tests/data/packages packages lock
+
 [testenv:package-version-checks]
 skipsdist = True
 usedevelop = True
@@ -314,8 +323,8 @@ deps =
     tomte[black]==0.1.5
 commands = pip install {toxinidir}[all]
            pip install --no-deps file://{toxinidir}/plugins/aea-cli-ipfs
-           python -m aea.cli generate-all-protocols
-           python -m aea.cli generate-all-protocols tests/data/packages
+           aea generate-all-protocols
+           aea generate-all-protocols tests/data/packages
 
 [testenv:check-generate-all-protocols]
 skipsdist = True

--- a/tox.ini
+++ b/tox.ini
@@ -185,6 +185,14 @@ skip_install = True
 deps =
 commands = {toxinidir}/scripts/check_copyright_notice.py --check
 
+[testenv:hash-all]
+skipsdist = True
+usedevelop = True
+commands =
+    pip install {toxinidir}[all]
+    aea hash all
+    aea hash all --packages-dir=./tests/data/packages
+
 [testenv:hash-check]
 skipsdist = True
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -306,6 +306,17 @@ deps =
     tomte[docs]==0.1.5
 commands = {toxinidir}/scripts/generate_api_docs.py --check-clean
 
+[testenv:generate-all-protocols]
+skipsdist = True
+usedevelop = True
+deps =
+    tomte[isort]==0.1.5
+    tomte[black]==0.1.5
+commands = pip install {toxinidir}[all]
+           pip install --no-deps file://{toxinidir}/plugins/aea-cli-ipfs
+           python -m aea.cli generate-all-protocols
+           python -m aea.cli generate-all-protocols tests/data/packages
+
 [testenv:check-generate-all-protocols]
 skipsdist = True
 usedevelop = True


### PR DESCRIPTION
## Proposed changes

make generators leads to failure
```
[2022-10-17 15:18:43,392][INFO] Generate the protocol. Command: ['generate', 'protocol', '../fipa.yaml']
Calling command ('/home/zarathustra/Repositories/valory/open-aea/.venv/bin/python', '-m', 'aea.cli', 'generate', 'protocol', '../fipa.yaml') with kwargs {}
protolint version master(latest)
Generating protocol 'fipa' and adding it to the agent 'my_aea'...
/home/zarathustra/Repositories/valory/open-aea/.venv/bin/python: No module named black
Error: Protocol is NOT generated. The following error happened while generating the protocol:
Command '['/home/zarathustra/Repositories/valory/open-aea/.venv/bin/python', '-m', 'black', './protocols/fipa', '--quiet']' returned non-zero exit status 1.
```

amended that

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
