### PR TITLE
tests: `test_remove_non_empty_test_directory`

### DIFF
--- a/docs/api/test_tools/utils.md
+++ b/docs/api/test_tools/utils.md
@@ -19,7 +19,7 @@ Wait for condition to occur in selected timeout.
 #### remove`_`test`_`directory
 
 ```python
-def remove_test_directory(directory: str, retries: int = 3) -> bool
+def remove_test_directory(directory: Union[str, Path], retries: int = 3) -> bool
 ```
 
 Destroy a directory once tests are done, change permissions if needed.

--- a/tests/test_test_tools/test_utils.py
+++ b/tests/test_test_tools/test_utils.py
@@ -19,11 +19,15 @@
 
 """Test utilities."""
 
+import os
+import shutil
 import tempfile
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
+from aea.test_tools import utils
 from aea.test_tools.utils import remove_test_directory, wait_for_condition
 
 
@@ -35,12 +39,18 @@ def test_wait_for_condition():
         wait_for_condition(lambda: False, error_msg="test error msg")
 
 
-def test_remove_test_directory():
+def test_remove_non_empty_test_directory():
     """Test remove_test_directory"""
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        assert remove_test_directory(str(tmp_dir))
+    tmp_dir = tempfile.TemporaryDirectory().name
+    assert not os.path.exists(tmp_dir)
+    shutil.copytree(str(Path(utils.__file__).parent), tmp_dir)
+    assert os.path.isdir(tmp_dir)
+    assert list(Path(tmp_dir).glob("*"))
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        with mock.patch("os.lstat", side_effect=Exception):
-            assert not remove_test_directory(tmp_dir)
+    with mock.patch("os.lstat", side_effect=Exception):
+        assert not remove_test_directory(tmp_dir)
+    assert os.path.exists(tmp_dir)
+
+    assert remove_test_directory(tmp_dir)
+    assert not os.path.exists(tmp_dir)

--- a/tests/test_test_tools/test_utils.py
+++ b/tests/test_test_tools/test_utils.py
@@ -39,18 +39,21 @@ def test_wait_for_condition():
         wait_for_condition(lambda: False, error_msg="test error msg")
 
 
-def test_remove_non_empty_test_directory():
+@pytest.mark.parametrize("path_type", [str, Path])
+def test_remove_non_empty_test_directory(path_type):
     """Test remove_test_directory"""
 
-    tmp_dir = tempfile.TemporaryDirectory().name
+    tmp_dir = path_type(tempfile.TemporaryDirectory().name)
     assert not os.path.exists(tmp_dir)
     shutil.copytree(str(Path(utils.__file__).parent), tmp_dir)
     assert os.path.isdir(tmp_dir)
     assert list(Path(tmp_dir).glob("*"))
 
+    permission = os.stat(tmp_dir).st_mode
     with mock.patch("os.lstat", side_effect=Exception):
         assert not remove_test_directory(tmp_dir)
     assert os.path.exists(tmp_dir)
+    assert os.stat(tmp_dir).st_mode == permission
 
     assert remove_test_directory(tmp_dir)
     assert not os.path.exists(tmp_dir)


### PR DESCRIPTION
## Proposed changes

Tests with context manager seen in base PR #381 are flaky on all OS. Furthermore they are ran on an empty directory, which is not a proper test case.

Failure observed in CI run of base PR:
- ubuntu: https://github.com/valory-xyz/open-aea/actions/runs/3296676265/jobs/5436717935
- macos: https://github.com/valory-xyz/open-aea/actions/runs/3296676265/jobs/5436718371
- windows: https://github.com/valory-xyz/open-aea/actions/runs/3296676265/jobs/5436718739

Showcasing failure to remove a directory using `remove_test_directory` before addressing the issue.

https://github.com/valory-xyz/open-aea/blob/beb421d2d3bea0463d1e32492425bb65c487d4e1/aea/test_tools/utils.py#L44-L68


## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...