### PR TITLE
Chore/minor p2p issues

### DIFF
--- a/docs/package_list.md
+++ b/docs/package_list.md
@@ -30,7 +30,7 @@
 | agent/open_aea/my_first_aea/0.1.0                             | `bafybeifelwg4md24lwpxgx7x5cugq7ovhbkew3lxw43m52rdppfn5o5g4i` |
 | connection/fetchai/local/0.20.0                               | `bafybeianwid4lh3ubjheg4ho7qznuib2t6k35rcuconcbwtzmih4qdxo2i` |
 | connection/valory/http_client/0.23.0                          | `bafybeihz3tubwado7j3wlivndzzuj3c6fdsp4ra5r3nqixn3ufawzo3wii` |
-| connection/valory/test_libp2p/0.1.0                           | `bafybeifyf64coc4fejcoba5bjymixnhtzb3vaojf2brz4xqb2oglmzxely` |
+| connection/valory/test_libp2p/0.1.0                           | `bafybeibnqzgf76bu2cqa7n3seeju3j7ukkorddb6n2xzx4bynh4swdk43q` |
 | protocol/fetchai/tac/1.0.0                                    | `bafybeiaew226n32rwp3h57zl4b2mmbrhjbyrdjbl2evnxf2tmmi4vrls7a` |
 | skill/fetchai/erc1155_client/0.28.0                           | `bafybeigjapreaqjqvcukrnqr4fzlrugl3635bh2abj3tnxqq247swqtl7u` |
 | skill/fetchai/erc1155_deploy/0.30.0                           | `bafybeibtjaylkd47ghbwgl7rdck2exvnrodwnyjhfvrtaluwrvkx5k5gtq` |

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -29,7 +29,7 @@
     "agent/open_aea/my_first_aea/0.1.0": "bafybeifelwg4md24lwpxgx7x5cugq7ovhbkew3lxw43m52rdppfn5o5g4i",
     "connection/fetchai/local/0.20.0": "bafybeianwid4lh3ubjheg4ho7qznuib2t6k35rcuconcbwtzmih4qdxo2i",
     "connection/valory/http_client/0.23.0": "bafybeihz3tubwado7j3wlivndzzuj3c6fdsp4ra5r3nqixn3ufawzo3wii",
-    "connection/valory/test_libp2p/0.1.0": "bafybeifyf64coc4fejcoba5bjymixnhtzb3vaojf2brz4xqb2oglmzxely",
+    "connection/valory/test_libp2p/0.1.0": "bafybeibnqzgf76bu2cqa7n3seeju3j7ukkorddb6n2xzx4bynh4swdk43q",
     "protocol/fetchai/tac/1.0.0": "bafybeiaew226n32rwp3h57zl4b2mmbrhjbyrdjbl2evnxf2tmmi4vrls7a",
     "skill/fetchai/erc1155_client/0.28.0": "bafybeigjapreaqjqvcukrnqr4fzlrugl3635bh2abj3tnxqq247swqtl7u",
     "skill/fetchai/erc1155_deploy/0.30.0": "bafybeibtjaylkd47ghbwgl7rdck2exvnrodwnyjhfvrtaluwrvkx5k5gtq",

--- a/packages/valory/connections/test_libp2p/connection.yaml
+++ b/packages/valory/connections/test_libp2p/connection.yaml
@@ -15,7 +15,7 @@ fingerprint:
   tests/base.py: bafybeifetr4vll34azapap52cwnhrwgvsgs4veld263vb277z6lzcti2si
   tests/conftest.py: bafybeifkjrvsysdb7ujp2wxurzgytzy3ecu6fv247zfszfymdvb7y7klpu
   tests/test_certificate_dates.py: bafybeif4t76wsvsfvvplkmi4gecgod6ijff3bbqgtaqmpep6ywfapfptfm
-  tests/test_dht.py: bafybeifbnvlt7ts4ol5ygs3f3ype2iyallcvnv6scjooypngov2quoqrfy
+  tests/test_dht.py: bafybeibobjncrjsovxt5m4vt5yto7dy5blovbom6x5icxugyxtc22f3tzu
   tests/test_p2p_libp2p/__init__.py: bafybeig7f7s5ptqtscf74y25dtqvhp75joekcxi6qnuzxgxyzictpsp4dm
   tests/test_p2p_libp2p/test_aea_cli.py: bafybeiej55kwbxuqjvjjz4tc7we54pxur7kvsh5o36lau7b7utltzwkc34
   tests/test_p2p_libp2p/test_communication.py: bafybeihnkle2pokfzfkguegmq4ptatvpcaezxrv564l76atjnuec57b2am
@@ -25,7 +25,7 @@ fingerprint:
   tests/test_p2p_libp2p/test_slow_queue.py: bafybeihx6dga3bxiy7i67ggf6gnoakygyf5djyzv6prias5tcjpxawlpyy
   tests/test_p2p_libp2p_client/__init__.py: bafybeihjzl7ireo5rbnxcdbghbncykgcgcbh26m4mjjofsseeflauuf6sy
   tests/test_p2p_libp2p_client/test_aea_cli.py: bafybeigcyn7yqcmfsdrrdy4dllqvkyhbdxywkfc3ikofczqqjhz4wsdr4y
-  tests/test_p2p_libp2p_client/test_communication.py: bafybeigflhmhqmfkytzhpcglmljvd3qqk6cpf6vci6hs4ceqwadc6azufa
+  tests/test_p2p_libp2p_client/test_communication.py: bafybeiceec5zsd2u37t56oiajijgwx7frpo3wzu4qdfd3lcq3lcldyqszq
   tests/test_p2p_libp2p_client/test_errors.py: bafybeiakajzr6jtecwnlzcrrx7paydz3obmleqzv7am5xbadu6wjtzabmm
   tests/test_p2p_libp2p_mailbox/__init__.py: bafybeiad64wftnugaahubhqc6bcqzg7om4435dzojdv7oeq4zdmn7kxzui
   tests/test_p2p_libp2p_mailbox/test_aea_cli.py: bafybeievjaiacpvcpabemtrmmeejbf4cbkrqzhu2ekxzyfyeg42ityxn5q

--- a/packages/valory/connections/test_libp2p/tests/test_dht.py
+++ b/packages/valory/connections/test_libp2p/tests/test_dht.py
@@ -214,7 +214,7 @@ test_classes = [
 
 
 @dataclass
-class TestCaseConfig:
+class NodeConfigTestCase:
     """TestCase"""
 
     name: str
@@ -225,8 +225,8 @@ class TestCaseConfig:
 # dynamically create tests
 for base_cls in test_classes:
     for test_case in (
-        TestCaseConfig("Local", local_nodes, True),
-        TestCaseConfig("Public", public_nodes),
+        NodeConfigTestCase("Local", local_nodes, True),
+        NodeConfigTestCase("Public", public_nodes),
     ):
         name = f"Test{test_case.name}{base_cls.__name__}"
 

--- a/packages/valory/connections/test_libp2p/tests/test_p2p_libp2p_client/test_communication.py
+++ b/packages/valory/connections/test_libp2p/tests/test_p2p_libp2p_client/test_communication.py
@@ -80,7 +80,6 @@ class TestLibp2pClientConnectionConnectDisconnect(BaseP2PLibp2pTest):
             await connection_node.disconnect()
 
 
-@pytest.mark.asyncio
 @libp2p_log_on_failure_all
 class TestLibp2pClientConnectionEchoEnvelope(BaseP2PLibp2pTest):
     """Test that connection will route envelope to destination through the same libp2p node"""


### PR DESCRIPTION
## Proposed changes

Two minor small issues addressed:
- remove `pytest.mark.asyncio` from non-async test
    ```
    packages/valory/connections/test_libp2p/tests/test_p2p_libp2p_client/test_communication.py::TestLibp2pClientConnectionEchoEnvelope::test_envelope_echoed_back_node_agent
      packages\valory\connections\test_libp2p\tests\test_p2p_libp2p_client\test_communication.py:143: PytestWarning: The test <Function test_envelope_echoed_back_node_agent> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
        def test_envelope_echoed_back_node_agent(self):
    
    packages/valory/connections/test_libp2p/tests/test_p2p_libp2p_client/test_communication.py::TestLibp2pClientConnectionEchoEnvelope::test_connection_is_established
      packages\valory\connections\test_libp2p\tests\test_p2p_libp2p_client\test_communication.py:110: PytestWarning: The test <Function test_connection_is_established> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
        def test_connection_is_established(self):
    
    packages/valory/connections/test_libp2p/tests/test_p2p_libp2p_client/test_communication.py::TestLibp2pClientConnectionEchoEnvelope::test_envelope_echoed_back
      packages\valory\connections\test_libp2p\tests\test_p2p_libp2p_client\test_communication.py:125: PytestWarning: The test <Function test_envelope_echoed_back> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
        def test_envelope_echoed_back(self):
    
    packages/valory/connections/test_libp2p/tests/test_p2p_libp2p_client/test_communication.py::TestLibp2pClientConnectionEchoEnvelope::test_envelope_routed
      packages\valory\connections\test_libp2p\tests\test_p2p_libp2p_client\test_communication.py:114: PytestWarning: The test <Function test_envelope_routed> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
        def test_envelope_routed(self):
    ```
- rename `TestCaseConfig` to `NodeConfigTestCase` to not interfere with pytest, which otherwise tries to execute it
   ```
   tests\test_dht.py:217
  D:\a\open-aea\open-aea\packages\valory\connections\test_libp2p\tests\test_dht.py:217: PytestCollectionWarning: cannot collect test class 'TestCaseConfig' because it has a __init__ constructor (from: packages/valory/connections/test_libp2p/tests/test_dht.py)
    class TestCaseConfig:
    ```
## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...