### PR TITLE
tests: copy_class

### DIFF
--- a/tests/test_test_tools/test_utils.py
+++ b/tests/test_test_tools/test_utils.py
@@ -18,7 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """Test utilities."""
-import logging
+
 import os
 import shutil
 import tempfile

--- a/tests/test_test_tools/test_utils.py
+++ b/tests/test_test_tools/test_utils.py
@@ -18,11 +18,12 @@
 # ------------------------------------------------------------------------------
 
 """Test utilities."""
-
+import logging
 import os
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Type
 from unittest import mock
 
 import pytest
@@ -39,30 +40,107 @@ def test_wait_for_condition():
         wait_for_condition(lambda: False, error_msg="test error msg")
 
 
-def test_copy_class():
+class TestCopyClass:
     """Test copy_class"""
 
-    class A:
-        """A"""
+    cls: Type
+    copy_of_cls: Type
 
-        attr = "attr"
+    def setup(self):
+        """Setup"""
 
-        def f(self) -> None:
-            """F"""
+        # redefine for each test
+        class Parent:
+            """Parent"""
 
-    copy_of_A = copy_class(A)
-    assert copy_of_A is not A
-    assert copy_of_A != A
-    assert copy_of_A.attr == A.attr
-    assert copy_of_A.f is A.f
-    assert copy_of_A().f != A().f
-    assert copy_of_A.__name__ == A.__name__
+            def __init__(self):
+                self.x = self._y = None
+                self.attr = "attr"
+                self.mutable_attr = []
 
-    # new attributes / methods on copy not present on original
-    copy_of_A.new_attr = "new_attr"
-    copy_of_A.g = lambda: None
-    assert not hasattr(A, "new_attr")
-    assert not hasattr(A, "g")
+        class Child(Parent):
+            """Child"""
+
+            cls_attr = "cls_attr"
+            cls_mutable_attr = []
+
+            def __init__(self):
+                super().__init__()
+
+            @classmethod
+            def cls_method(cls, x):
+                cls.x = x
+
+            def method(self, y):
+                """F"""
+                self._y = y
+
+            @property
+            def y(self):
+                return self._y
+
+        self.cls = Child
+        self.copy_of_cls = copy_class(Child)
+
+    @pytest.mark.parametrize("mutate_original", [False, True])
+    def test_cls(self, mutate_original: bool):
+        """Test cls"""
+
+        original, replica = self.cls, self.copy_of_cls
+        a, b = (original, replica) if mutate_original else (replica, original)
+
+        assert a is not b
+        assert a != b
+        assert a.cls_attr == b.cls_attr
+        assert a.cls_mutable_attr == b.cls_mutable_attr
+
+        # mutate state
+        assert not hasattr(a, "x")
+        a.cls_method(3)
+        assert hasattr(a, "x")
+        a.cls_mutable_attr.append(1)
+        assert a.cls_mutable_attr
+        assert not b.cls_mutable_attr
+
+        # if we set the attribute on the original (parent class),
+        # the replicate (child) will also have it.
+        a.new_attr = "new_attr"
+        a.g = lambda: None
+        if not mutate_original:
+            assert not hasattr(b, "x")
+            assert not hasattr(b, "new_attr")
+            assert not hasattr(b, "g")
+
+    @pytest.mark.parametrize("mutate_original", [False, True])
+    def test_instance(self, mutate_original: bool):
+        """Test instance"""
+
+        original, replica = self.cls(), self.copy_of_cls()
+        a, b = (original, replica) if mutate_original else (replica, original)
+
+        assert a is not b
+        assert a != b
+        assert a.cls_attr == b.cls_attr
+        assert a.cls_mutable_attr == b.cls_mutable_attr
+
+        # mutate state
+        assert hasattr(a, "x") and hasattr(b, "x")  # set in __init__
+        a.cls_method(3)
+        assert a.x is b.x is None  # class method does not affect instance
+
+        a.method(3)
+        assert a.y == 3
+        assert b.y is None
+
+        a.cls_mutable_attr.append(1)
+        assert a.cls_mutable_attr
+        assert not b.cls_mutable_attr
+
+        # mutating instance attributes in not heritable
+        a.new_attr = "new_attr"
+        a.g = lambda: None
+        assert not hasattr(b, "new_attr")
+        assert not hasattr(b, "g")
 
 
 @pytest.mark.parametrize("path_type", [str, Path])


### PR DESCRIPTION
## Proposed changes

There are several issue with the `copy_class` method introduced in PR #410 

One of these is the fact that `super().__init__()` will throw and error when using the copy, as seen in PR #413 
    ```
    E       TypeError: super(type, obj): obj must be an instance or subtype of type
    ```

Another one is that mutable types are copied by reference, meaning that a mutable class argument that is modified will change the state lastingly, which is not in line with the intended purpose of the `copy_class` method.

This PR shows these failures

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
