### PR TITLE
Release v1.22.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,34 @@
 # Release History - open AEA
 
+## 1.22.0 (2022-11-1)
+
+AEA:
+- Updates the cert request serialisation process to maintain consistency across different operating systems
+- Updates the `get_or_create_cli_config` method to return default config instead of creating one
+- Introduces the `copy_class` utility function for testing different setup configurations
+- Updates the overridable policies for the configuration classes
+
+Packages:
+- Removes the unwanted autonomy dependency from the ledger connection
+  
+Tests:
+- Updates the cli config fixture to retain user config
+- Fixes outbox check test 
+- Adds test coverage for
+  - `aea/cli`
+  - `aea/configurations`
+  - `aea/helpers`
+  - `aea/test_tools`
+  - `aea/manager`
+
+Docs:
+- Adds documentation on the usage of component overrides
+
+Chores:
+- Adds a script to automatically generate a package table for the docs
+- Introduces the usage of `tomte` to maintain third party dependency version consistency
+- Updates the script to check the broken links to use parallelization
+
 ## 1.21.0 (2022-09-28)
 
 AEA:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-aea` are currently being suppo
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `1.21.x`   | :white_check_mark: |
-| `< 1.21.0` | :x:                |
+| `1.22.x`   | :white_check_mark: |
+| `< 1.22.0` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.21.0"
+__version__ = "1.22.0"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.21.0 "open-aea-cli-ipfs<2.0.0,>=1.21.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.22.0 "open-aea-cli-ipfs<2.0.0,>=1.21.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.22.0 "open-aea-cli-ipfs<2.0.0,>=1.21.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.22.0 "open-aea-cli-ipfs<2.0.0,>=1.22.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.21.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.22.0/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.21.0
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.22.0
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,8 +7,13 @@ Below we describe the additional manual steps required to upgrade between differ
 
 # Open AEA
 
-## `v1.20.0` to `v1.21.0`
+## `v1.21.0` to `v1.22.0`
 
+No backwards incompatible changes.
+
+Plugins from previous versions are not compatible anymore.
+
+## `v1.20.0` to `v1.21.0`
 
 No backwards incompatible changes.
 

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.21.0
+RUN pip install --upgrade --force-reinstall aea[all]==1.22.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-benchmark",
-    version="1.21.0",
+    version="1.22.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.21.0",
+    version="1.22.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.21.0",
+    version="1.22.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.21.0",
+    version="1.22.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.21.0",
+    version="1.22.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",

--- a/scripts/RELEASE_PROCESS.md
+++ b/scripts/RELEASE_PROCESS.md
@@ -17,7 +17,7 @@
 
 7. Check the package upgrades are correct by running `python -m aea.cli check-packages` and `python scripts/check_package_versions_in_docs.py`. Commit if satisfied.
 
-8. Check the docs are up-to-date by running `python scripts/generate_api_docs.py`, `python scripts/check_doc_ipfs_hashes.py --fix` and `python scripts/check_doc_links.py`. Ensure all links are configured `mkdocs serve`. Commit if satisfied.
+8. Check the docs are up-to-date by running `tox -e generate-api-documentation`, `python scripts/check_doc_ipfs_hashes.py --fix` and `python scripts/check_doc_links.py`. Ensure all links are configured `mkdocs serve`. Commit if satisfied.
 
 9. Ensure the signing protocol hash in open-aea is updated: `tests/test_configurations/test_constants.py::test_signing_protocol_hash`
 

--- a/scripts/check_pipfile_and_toxini.py
+++ b/scripts/check_pipfile_and_toxini.py
@@ -39,8 +39,6 @@ WHITELIST = {
     "tomte[safety]": "==0.1.5",
     "tomte[vulture]": "==0.1.5",
     "tomte[darglint]": "==0.1.5",
-    "open-aea[all]": "==1.21.0.post1",
-    "open-aea-cli-ipfs": "==1.21.0",
 }
 
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.21.0 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.22.0 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.21.0 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.22.0 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.21.0"
+      template: "1.22.0"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.21.0"
+          template: "1.22.0"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -44,7 +44,7 @@ pip install open-aea[all]
 pip install open-aea-cli-ipfs
 ```
 ```
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.21.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.22.0/packages packages
 ```
 
 ``` bash

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.21.0
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.22.0
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.22.0

## Release details

AEA:
- Updates the cert request serialisation process to maintain consistency across different operating systems
- Updates the `get_or_create_cli_config` method to return default config instead of creating one
- Introduces the `copy_class` utility function for testing different setup configurations
- Updates the overridable policies for the configuration classes

Packages:
- Removes the unwanted autonomy dependency from the ledger connection

Tests:
- Updates the cli config fixture to retain user config
- Fixes outbox check test 
- Adds test coverage for
  - `aea/cli`
  - `aea/configurations`
  - `aea/helpers`
  - `aea/test_tools`
  - `aea/manager`

Docs:
- Adds documentation on the usage of component overrides

Chores:
- Adds a script to automatically generate a package table for the docs
- Introduces the usage of `tomte` to maintain third party dependency version consistency
- Updates the script to check the broken links to use parallelization

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side), from `develop`
- [x] Lint and unit tests pass locally and in CI
- [x] I have checked the fingerprint hashes are correct by running (`aea hash all` and `aea packages lock --check`)
- [x] I have regenerated the latest API docs
- [x] I built the documentation and updated it with the latest changes
- [x] I have added an item in `HISTORY.md` for this release
- [x] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.
