### PR TITLE
Make sure we skip `open-aea` when generating list for third party packages in package dependency check

### DIFF
--- a/aea/cli/check_packages.py
+++ b/aea/cli/check_packages.py
@@ -491,7 +491,7 @@ class ImportsTool:
             pyfile = cls.get_module_file(module_name)
             if not pyfile:
                 continue
-            if "site-packages" not in Path(pyfile).parts:
+            if "site-packages" not in Path(pyfile).parts or "aea" in Path(pyfile).parts:
                 continue
             yield module_name, Path(pyfile)
 


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug in `check-packages` command introduced with the last release

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules