### PR TITLE
[WIP] Make sure package manager is backwards compatible

### DIFF
--- a/aea/package_manager/v0.py
+++ b/aea/package_manager/v0.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2022 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Package manager V0"""
+
+import json
+import traceback
+from collections import OrderedDict
+from pathlib import Path
+from typing import Callable
+from typing import OrderedDict as OrderedDictType
+
+from aea.configurations.base import PackageConfiguration
+from aea.configurations.data_types import PackageId, PackageType
+from aea.helpers.fingerprint import check_fingerprint
+from aea.helpers.io import open_file
+from aea.helpers.ipfs.base import IPFSHashOnly
+from aea.package_manager.base import (
+    BasePackageManager,
+    PACKAGES_FILE,
+    PackageIdToHashMapping,
+    load_configuration,
+)
+
+
+class PackageManagerV0(BasePackageManager):
+    """Package manager v0."""
+
+    _packages: OrderedDictType[PackageId, str]
+
+    def __init__(self, path: Path, packages: PackageIdToHashMapping) -> None:
+        """Initialize object."""
+
+        super().__init__(path)
+
+        self._packages = packages or OrderedDict()
+
+    @property
+    def packages(
+        self,
+    ) -> OrderedDictType[PackageId, str]:
+        """Returns mappings of package ids -> package hash"""
+
+        return self._packages
+
+    def sync(
+        self,
+        dev: bool = False,
+        third_party: bool = True,
+        update_packages: bool = False,
+        update_hashes: bool = False,
+    ) -> "PackageManagerV0":
+        """Sync local packages to the remote registry."""
+
+        if update_packages and update_hashes:
+            raise ValueError(
+                "Both `update_packages` and `update_hashes` cannot be set to `True`."
+            )
+
+        self._logger.info(f"Performing sync @ {self.path}")
+        sync_needed, hash_updates, package_updates = self._sync(
+            packages=self.packages,
+            update_hashes=update_hashes,
+            update_packages=update_packages,
+        )
+
+        if update_hashes:
+            self._packages = hash_updates
+
+        if update_packages and package_updates:
+            self._logger.info("Updating dev packages.")
+            for package_id, _ in package_updates.items():
+                self._logger.info(f"Updating {package_id}")
+                self.update_package(package_id=package_id)
+
+        if sync_needed:
+            self._logger.info("Sync complete")
+        else:
+            self._logger.info("No package was updated.")
+
+        return self
+
+    def update_package_hashes(self) -> "PackageManagerV0":
+        """Update packages.json file."""
+        self._packages.update(self.get_available_package_hashes())
+        return self
+
+    def verify(
+        self,
+        config_loader: Callable[
+            [PackageType, Path], PackageConfiguration
+        ] = load_configuration,
+    ) -> int:
+        """Verify fingerprints and outer hash of all available packages."""
+
+        failed = False
+        try:
+            available_packages = self.get_available_package_hashes()
+            for package_id in available_packages:
+                package_path = self.package_path_from_package_id(package_id)
+                configuration_obj = config_loader(
+                    package_id.package_type,
+                    package_path,
+                )
+
+                fingerprint_check = check_fingerprint(configuration_obj)
+                if not fingerprint_check:
+                    failed = True
+                    self._logger.info(
+                        f"Fingerprints does not match for {package_id} @ {package_path}"
+                    )
+                    continue
+
+                expected_hash = self.packages.get(package_id)
+                if expected_hash is None:
+                    failed = True
+                    self._logger.info(f"Cannot find hash for {package_id}")
+                    continue
+
+                calculated_hash = IPFSHashOnly.get(str(package_path))
+                if calculated_hash != expected_hash:
+                    failed = True
+                    self._logger.info(
+                        f"\nHash does not match for {package_id}\n\tCalculated hash: {calculated_hash}\n\tExpected hash: {expected_hash}"
+                    )
+
+        except Exception:  # pylint: disable=broad-except
+            traceback.print_exc()
+            failed = True
+
+        return int(failed)
+
+    @property
+    def json(
+        self,
+    ) -> OrderedDictType:
+        """Json representation."""
+        data = OrderedDict()
+        for package_id, package_hash in self._packages.items():
+            data[package_id.to_uri_path] = package_hash
+        return data
+
+    @classmethod
+    def from_dir(cls, packages_dir: Path) -> "PackageManagerV0":
+        """Initialize from packages directory."""
+
+        packages_file = packages_dir / PACKAGES_FILE
+        with open_file(packages_file, "r") as fp:
+            _packages = json.load(fp)
+
+        packages = OrderedDict()
+        for package_id, package_hash in _packages.items():
+            packages[PackageId.from_uri_path(package_id)] = package_hash
+
+        return cls(packages_dir, packages)

--- a/aea/package_manager/v1.py
+++ b/aea/package_manager/v1.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2022 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Package manager V1"""
+
+import json
+import traceback
+from collections import OrderedDict
+from pathlib import Path
+from typing import Callable, Optional
+from typing import OrderedDict as OrderedDictType
+
+from aea.configurations.base import PackageConfiguration
+from aea.configurations.data_types import PackageId, PackageType
+from aea.helpers.fingerprint import check_fingerprint
+from aea.helpers.io import open_file
+from aea.helpers.ipfs.base import IPFSHashOnly
+from aea.package_manager.base import (
+    BasePackageManager,
+    PACKAGES_FILE,
+    PackageFileNotValid,
+    PackageIdToHashMapping,
+    PackageNotValid,
+    load_configuration,
+)
+
+
+class PackageManagerV1(BasePackageManager):
+    """Package manager V1"""
+
+    _third_party_packages: PackageIdToHashMapping
+    _dev_packages: PackageIdToHashMapping
+
+    def __init__(
+        self,
+        path: Path,
+        dev_packages: Optional[PackageIdToHashMapping] = None,
+        third_party_packages: Optional[PackageIdToHashMapping] = None,
+    ) -> None:
+        """Initialize object."""
+
+        super().__init__(path)
+
+        self._dev_packages = dev_packages or OrderedDict()
+        self._third_party_packages = third_party_packages or OrderedDict()
+
+    @property
+    def dev_packages(
+        self,
+    ) -> PackageIdToHashMapping:
+        """Returns mappings of package ids -> package hash"""
+
+        return self._dev_packages
+
+    @property
+    def third_party_packages(
+        self,
+    ) -> PackageIdToHashMapping:
+        """Returns mappings of package ids -> package hash"""
+
+        return self._third_party_packages
+
+    def sync(
+        self,
+        dev: bool = False,
+        third_party: bool = True,
+        update_packages: bool = False,
+        update_hashes: bool = False,
+    ) -> "PackageManagerV1":
+        """Sync local packages to the remote registry."""
+
+        if update_packages and update_hashes:
+            raise ValueError(
+                "Both `update_packages` and `update_hashes` cannot be set to `True`."
+            )
+
+        self._logger.info(f"Performing sync @ {self.path}")
+
+        sync_needed = False
+
+        if third_party:
+            self._logger.info("Checking third party packages.")
+            (
+                _sync_needed,
+                hash_updates_third_party,
+                package_updates_third_party,
+            ) = self._sync(
+                packages=self.third_party_packages,
+                update_hashes=update_hashes,
+                update_packages=update_packages,
+            )
+            sync_needed = sync_needed or _sync_needed
+
+            if update_hashes and hash_updates_third_party:
+                third_party_package_id = "\n\t- ".join(
+                    map(str, hash_updates_third_party)
+                )
+                self._logger.warning(
+                    f"Hashes for follwing third party module has changed.\n\t- {third_party_package_id}"
+                )
+
+            if update_packages and package_updates_third_party:
+                self._logger.info("Updating third party packages.")
+                for package_id, _ in package_updates_third_party.items():
+                    self._logger.info(f"Updating {package_id}")
+                    self.update_package(package_id=package_id)
+
+        if dev:
+            self._logger.info("Checking dev packages.")
+            _sync_needed, hash_updates_dev, package_updates_dev = self._sync(
+                packages=self.dev_packages,
+                update_hashes=update_hashes,
+                update_packages=update_packages,
+            )
+            sync_needed = sync_needed or _sync_needed
+
+            if update_hashes:
+                self._dev_packages = hash_updates_dev
+
+            if update_packages and package_updates_dev:
+                self._logger.info("Updating dev packages.")
+                for package_id, _ in package_updates_dev.items():
+                    self._logger.info(f"Updating {package_id}")
+                    self.update_package(package_id=package_id)
+
+        if update_hashes:
+            self._logger.info("Updating hashes")
+            self.dump()
+
+        if sync_needed:
+            self._logger.info("Sync complete")
+        else:
+            self._logger.info("No package was updated.")
+
+        return self
+
+    def update_package_hashes(self) -> "PackageManagerV1":
+        """Update package.json file."""
+        for package_id, package_hash in self.get_available_package_hashes().items():
+            is_dev_package = package_id in self._dev_packages
+            is_third_party_package = package_id in self._third_party_packages
+            if not is_dev_package and not is_third_party_package:
+                raise PackageNotValid(
+                    f"Found a package which is not listed in the `packages.json` with package id {package_id}"
+                )
+
+            if is_dev_package:
+                if self._dev_packages[package_id] == package_hash:
+                    continue
+
+                self._logger.info(f"Updating hash for {package_id}")
+                self._dev_packages[package_id] = package_hash
+
+        return self
+
+    def verify(
+        self,
+        config_loader: Callable[
+            [PackageType, Path], PackageConfiguration
+        ] = load_configuration,
+    ) -> int:
+        """Verify fingerprints and outer hash of all available packages."""
+
+        failed = False
+        try:
+            available_packages = self.get_available_package_hashes()
+            for package_id in available_packages:
+                self._logger.info(f"Verifying {package_id}")
+                package_path = self.package_path_from_package_id(package_id)
+                configuration_obj = config_loader(
+                    package_id.package_type,
+                    package_path,
+                )
+
+                fingerprint_check = check_fingerprint(configuration_obj)
+                if not fingerprint_check:
+                    failed = True
+                    self._logger.info(
+                        f"Fingerprints does not match for {package_id} @ {package_path}"
+                    )
+                    continue
+
+                expected_hash = self.dev_packages.get(
+                    package_id, self.third_party_packages.get(package_id)
+                )
+
+                if expected_hash is None:
+                    failed = True
+                    self._logger.info(f"Cannot find hash for {package_id}")
+                    continue
+
+                calculated_hash = IPFSHashOnly.get(str(package_path))
+                if calculated_hash != expected_hash:
+                    failed = True
+                    self._logger.info(f"Hash does not match for {package_id}")
+                    self._logger.info(f"\tCalculated hash: {calculated_hash}")
+                    self._logger.info(f"\tExpected hash: {expected_hash}")
+
+        except Exception:  # pylint: disable=broad-except
+            traceback.print_exc()
+            failed = True
+
+        return int(failed)
+
+    @property
+    def json(
+        self,
+    ) -> OrderedDictType:
+        """Json representation"""
+
+        data: OrderedDictType[str, OrderedDictType[str, str]] = OrderedDict()
+        data["dev"] = OrderedDict()
+        data["third_party"] = OrderedDict()
+
+        for package_id, package_hash in self._dev_packages.items():
+            data["dev"][package_id.to_uri_path] = package_hash
+
+        for package_id, package_hash in self._third_party_packages.items():
+            data["third_party"][package_id.to_uri_path] = package_hash
+
+        return data
+
+    @classmethod
+    def from_dir(cls, packages_dir: Path) -> "PackageManagerV1":
+        """Initialize from packages directory."""
+
+        packages_file = packages_dir / PACKAGES_FILE
+        with open_file(packages_file, "r") as fp:
+            _packages = json.load(fp)
+
+        if "dev" not in _packages or "third_party" not in _packages:
+            raise PackageFileNotValid("Package file not valid.")
+
+        dev_packages = OrderedDict()
+        for package_id, package_hash in _packages["dev"].items():
+            dev_packages[PackageId.from_uri_path(package_id)] = package_hash
+
+        third_party_packages = OrderedDict()
+        for package_id, package_hash in _packages["third_party"].items():
+            third_party_packages[PackageId.from_uri_path(package_id)] = package_hash
+
+        return cls(packages_dir, dev_packages, third_party_packages)

--- a/docs/api/package_manager/base.md
+++ b/docs/api/package_manager/base.md
@@ -23,100 +23,37 @@ Load a configuration, knowing the type and the path to the package root.
 
 the configuration object.
 
-<a id="aea.package_manager.base.PackageManager"></a>
+<a id="aea.package_manager.base.BasePackageManager"></a>
 
-## PackageManager Objects
+## BasePackageManager Objects
 
 ```python
-class PackageManager()
+class BasePackageManager()
 ```
 
 AEA package manager
 
-<a id="aea.package_manager.base.PackageManager.__init__"></a>
+<a id="aea.package_manager.base.BasePackageManager.__init__"></a>
 
 #### `__`init`__`
 
 ```python
-def __init__(path: Path, packages: Optional[OrderedDictType[PackageId, str]] = None) -> None
+def __init__(path: Path) -> None
 ```
 
 Initialize object.
 
-<a id="aea.package_manager.base.PackageManager.packages"></a>
-
-#### packages
-
-```python
-@property
-def packages() -> OrderedDictType[PackageId, str]
-```
-
-Returns mappings of package ids -> package hash
-
-<a id="aea.package_manager.base.PackageManager.sync"></a>
-
-#### sync
-
-```python
-def sync(update_packages: bool = False, update_hashes: bool = False) -> "PackageManager"
-```
-
-Sync local packages to the remote registry.
-
-**Arguments**:
-
-                        package does not match the one in the packages.json.
-                      hash for a package does not match the one in the
-                      packages.json.
-- `update_packages`: Update packages if the calculated hash for a
-- `update_hashes`: Update hashes in the packages.json if the calculated
-
-**Returns**:
-
-PackageManager object
-
-<a id="aea.package_manager.base.PackageManager.add_package"></a>
+<a id="aea.package_manager.base.BasePackageManager.add_package"></a>
 
 #### add`_`package
 
 ```python
-def add_package(package_id: PackageId) -> "PackageManager"
+def add_package(package_id: PackageId) -> "BasePackageManager"
 ```
 
 Add packages.
 
-<a id="aea.package_manager.base.PackageManager.update_package"></a>
-
-#### update`_`package
-
-```python
-def update_package(package_path: Path, package_id: PackageId) -> "PackageManager"
-```
-
-Update package.
-
-<a id="aea.package_manager.base.PackageManager.get_available_package_hashes"></a>
-
-#### get`_`available`_`package`_`hashes
-
-```python
-def get_available_package_hashes() -> OrderedDictType[PackageId, str]
-```
-
-Returns a mapping object between available packages and their hashes
-
-<a id="aea.package_manager.base.PackageManager.update_package_hashes"></a>
-
-#### update`_`package`_`hashes
-
-```python
-def update_package_hashes() -> "PackageManager"
-```
-
-Initialize package.json file.
-
-<a id="aea.package_manager.base.PackageManager.package_path_from_package_id"></a>
+<a id="aea.package_manager.base.BasePackageManager.package_path_from_package_id"></a>
 
 #### package`_`path`_`from`_`package`_`id
 
@@ -126,11 +63,54 @@ def package_path_from_package_id(package_id: PackageId) -> Path
 
 Get package path from the package id.
 
-<a id="aea.package_manager.base.PackageManager.verify"></a>
+<a id="aea.package_manager.base.BasePackageManager.update_package"></a>
+
+#### update`_`package
+
+```python
+def update_package(package_id: PackageId) -> "BasePackageManager"
+```
+
+Update package.
+
+<a id="aea.package_manager.base.BasePackageManager.get_available_package_hashes"></a>
+
+#### get`_`available`_`package`_`hashes
+
+```python
+def get_available_package_hashes() -> PackageIdToHashMapping
+```
+
+Returns a mapping object between available packages and their hashes
+
+<a id="aea.package_manager.base.BasePackageManager.sync"></a>
+
+#### sync
+
+```python
+@abstractmethod
+def sync(dev: bool = False, third_party: bool = True, update_packages: bool = False, update_hashes: bool = False) -> "BasePackageManager"
+```
+
+Sync local packages to the remote registry.
+
+<a id="aea.package_manager.base.BasePackageManager.update_package_hashes"></a>
+
+#### update`_`package`_`hashes
+
+```python
+@abstractmethod
+def update_package_hashes() -> "BasePackageManager"
+```
+
+Update package.json file.
+
+<a id="aea.package_manager.base.BasePackageManager.verify"></a>
 
 #### verify
 
 ```python
+@abstractmethod
 def verify(config_loader: Callable[
             [PackageType, Path], PackageConfiguration
         ] = load_configuration) -> int
@@ -138,7 +118,19 @@ def verify(config_loader: Callable[
 
 Verify fingerprints and outer hash of all available packages.
 
-<a id="aea.package_manager.base.PackageManager.dump"></a>
+<a id="aea.package_manager.base.BasePackageManager.json"></a>
+
+#### json
+
+```python
+@property
+@abstractmethod
+def json() -> OrderedDictType
+```
+
+Json representation
+
+<a id="aea.package_manager.base.BasePackageManager.dump"></a>
 
 #### dump
 
@@ -148,24 +140,14 @@ def dump(file: Optional[Path] = None) -> None
 
 Dump package data to file.
 
-<a id="aea.package_manager.base.PackageManager.json"></a>
-
-#### json
-
-```python
-@property
-def json() -> OrderedDictType
-```
-
-Json representation
-
-<a id="aea.package_manager.base.PackageManager.from_dir"></a>
+<a id="aea.package_manager.base.BasePackageManager.from_dir"></a>
 
 #### from`_`dir
 
 ```python
 @classmethod
-def from_dir(cls, packages_dir: Path) -> "PackageManager"
+@abstractmethod
+def from_dir(cls, packages_dir: Path) -> "BasePackageManager"
 ```
 
 Initialize from packages directory.
@@ -189,4 +171,24 @@ class PackageUpdateError(Exception)
 ```
 
 Package update error.
+
+<a id="aea.package_manager.base.PackageNotValid"></a>
+
+## PackageNotValid Objects
+
+```python
+class PackageNotValid(Exception)
+```
+
+Package not valid.
+
+<a id="aea.package_manager.base.PackageFileNotValid"></a>
+
+## PackageFileNotValid Objects
+
+```python
+class PackageFileNotValid(Exception)
+```
+
+Package file not valid.
 

--- a/docs/api/package_manager/v0.md
+++ b/docs/api/package_manager/v0.md
@@ -1,0 +1,91 @@
+<a id="aea.package_manager.v0"></a>
+
+# aea.package`_`manager.v0
+
+Package manager V0
+
+<a id="aea.package_manager.v0.PackageManagerV0"></a>
+
+## PackageManagerV0 Objects
+
+```python
+class PackageManagerV0(BasePackageManager)
+```
+
+Package manager v0.
+
+<a id="aea.package_manager.v0.PackageManagerV0.__init__"></a>
+
+#### `__`init`__`
+
+```python
+def __init__(path: Path, packages: PackageIdToHashMapping) -> None
+```
+
+Initialize object.
+
+<a id="aea.package_manager.v0.PackageManagerV0.packages"></a>
+
+#### packages
+
+```python
+@property
+def packages() -> OrderedDictType[PackageId, str]
+```
+
+Returns mappings of package ids -> package hash
+
+<a id="aea.package_manager.v0.PackageManagerV0.sync"></a>
+
+#### sync
+
+```python
+def sync(dev: bool = False, third_party: bool = True, update_packages: bool = False, update_hashes: bool = False) -> "PackageManagerV0"
+```
+
+Sync local packages to the remote registry.
+
+<a id="aea.package_manager.v0.PackageManagerV0.update_package_hashes"></a>
+
+#### update`_`package`_`hashes
+
+```python
+def update_package_hashes() -> "PackageManagerV0"
+```
+
+Update packages.json file.
+
+<a id="aea.package_manager.v0.PackageManagerV0.verify"></a>
+
+#### verify
+
+```python
+def verify(config_loader: Callable[
+            [PackageType, Path], PackageConfiguration
+        ] = load_configuration) -> int
+```
+
+Verify fingerprints and outer hash of all available packages.
+
+<a id="aea.package_manager.v0.PackageManagerV0.json"></a>
+
+#### json
+
+```python
+@property
+def json() -> OrderedDictType
+```
+
+Json representation.
+
+<a id="aea.package_manager.v0.PackageManagerV0.from_dir"></a>
+
+#### from`_`dir
+
+```python
+@classmethod
+def from_dir(cls, packages_dir: Path) -> "PackageManagerV0"
+```
+
+Initialize from packages directory.
+

--- a/docs/api/package_manager/v1.md
+++ b/docs/api/package_manager/v1.md
@@ -1,0 +1,102 @@
+<a id="aea.package_manager.v1"></a>
+
+# aea.package`_`manager.v1
+
+Package manager V1
+
+<a id="aea.package_manager.v1.PackageManagerV1"></a>
+
+## PackageManagerV1 Objects
+
+```python
+class PackageManagerV1(BasePackageManager)
+```
+
+Package manager V1
+
+<a id="aea.package_manager.v1.PackageManagerV1.__init__"></a>
+
+#### `__`init`__`
+
+```python
+def __init__(path: Path, dev_packages: Optional[PackageIdToHashMapping] = None, third_party_packages: Optional[PackageIdToHashMapping] = None) -> None
+```
+
+Initialize object.
+
+<a id="aea.package_manager.v1.PackageManagerV1.dev_packages"></a>
+
+#### dev`_`packages
+
+```python
+@property
+def dev_packages() -> PackageIdToHashMapping
+```
+
+Returns mappings of package ids -> package hash
+
+<a id="aea.package_manager.v1.PackageManagerV1.third_party_packages"></a>
+
+#### third`_`party`_`packages
+
+```python
+@property
+def third_party_packages() -> PackageIdToHashMapping
+```
+
+Returns mappings of package ids -> package hash
+
+<a id="aea.package_manager.v1.PackageManagerV1.sync"></a>
+
+#### sync
+
+```python
+def sync(dev: bool = False, third_party: bool = True, update_packages: bool = False, update_hashes: bool = False) -> "PackageManagerV1"
+```
+
+Sync local packages to the remote registry.
+
+<a id="aea.package_manager.v1.PackageManagerV1.update_package_hashes"></a>
+
+#### update`_`package`_`hashes
+
+```python
+def update_package_hashes() -> "PackageManagerV1"
+```
+
+Update package.json file.
+
+<a id="aea.package_manager.v1.PackageManagerV1.verify"></a>
+
+#### verify
+
+```python
+def verify(config_loader: Callable[
+            [PackageType, Path], PackageConfiguration
+        ] = load_configuration) -> int
+```
+
+Verify fingerprints and outer hash of all available packages.
+
+<a id="aea.package_manager.v1.PackageManagerV1.json"></a>
+
+#### json
+
+```python
+@property
+def json() -> OrderedDictType
+```
+
+Json representation
+
+<a id="aea.package_manager.v1.PackageManagerV1.from_dir"></a>
+
+#### from`_`dir
+
+```python
+@classmethod
+def from_dir(cls, packages_dir: Path) -> "PackageManagerV1"
+```
+
+Initialize from packages directory.
+

--- a/tests/test_cli/test_package_manager/test_lock.py
+++ b/tests/test_cli/test_package_manager/test_lock.py
@@ -28,7 +28,8 @@ from unittest import mock
 from aea.cli import cli
 from aea.configurations.constants import PACKAGES
 from aea.configurations.data_types import PackageId
-from aea.package_manager.base import PACKAGES_FILE, PackageManager
+from aea.package_manager.base import PACKAGES_FILE
+from aea.package_manager.v1 import PackageManagerV1
 from aea.test_tools.test_cases import BaseAEATestCase
 
 
@@ -62,7 +63,7 @@ class TestLockCommand(BaseAEATestCase):
         ] = "bafybeiambqptflge33eemdhis2whik67hjplfnqwieoa6wblzlaf7vu"
 
         with mock.patch.object(
-            PackageManager, "dev_packages", new=dev_packages
+            PackageManagerV1, "dev_packages", new=dev_packages
         ), caplog.at_level(logging.INFO):
             result = self.runner.invoke(cli, ["packages", "lock", "--check"])
             assert result.exit_code == 1

--- a/tests/test_cli/test_package_manager/test_sync.py
+++ b/tests/test_cli/test_package_manager/test_sync.py
@@ -30,7 +30,8 @@ import pytest
 
 from aea.configurations.constants import PACKAGES
 from aea.configurations.data_types import PackageId
-from aea.package_manager.base import PACKAGES_FILE, PackageManager
+from aea.package_manager.base import PACKAGES_FILE
+from aea.package_manager.v1 import PackageManagerV1
 from aea.test_tools.test_cases import BaseAEATestCase
 
 
@@ -61,7 +62,7 @@ class TestSyncCommand(BaseAEATestCase):
         ] = "bafybeidv77u2xl52mnxakwvh7fuh46aiwfpteyof4eaptfd4agoi6cdblb"
 
         with mock.patch.object(
-            PackageManager, "dev_packages", new=packages
+            PackageManagerV1, "dev_packages", new=packages
         ), caplog.at_level(logging.INFO):
             result = self.run_cli_command("packages", "sync", "--dev")
             assert result.exit_code == 0
@@ -80,7 +81,7 @@ class TestSyncCommand(BaseAEATestCase):
         }
 
         with mock.patch.object(
-            PackageManager, "third_party_packages", new=packages
+            PackageManagerV1, "third_party_packages", new=packages
         ), caplog.at_level(logging.INFO):
             result = self.run_cli_command("packages", "sync")
             assert result.exit_code == 0
@@ -98,7 +99,7 @@ class TestSyncCommand(BaseAEATestCase):
             ): "bafybeiambqptflge33eemdhis2whik67hjplfnqwieoa6wblzlaf7vuo41"
         }
 
-        with mock.patch.object(PackageManager, "third_party_packages", new=packages):
+        with mock.patch.object(PackageManagerV1, "third_party_packages", new=packages):
             with pytest.raises(
                 click.ClickException,
                 match=re.escape(
@@ -108,7 +109,7 @@ class TestSyncCommand(BaseAEATestCase):
                 self.run_cli_command("packages", "sync")
 
         with mock.patch.object(
-            PackageManager, "third_party_packages", new=packages
+            PackageManagerV1, "third_party_packages", new=packages
         ), mock.patch("shutil.rmtree"), caplog.at_level(logging.INFO):
             result = self.run_cli_command(
                 "packages",
@@ -122,7 +123,7 @@ class TestSyncCommand(BaseAEATestCase):
             )
 
         with mock.patch.object(
-            PackageManager, "third_party_packages", new=packages
+            PackageManagerV1, "third_party_packages", new=packages
         ), mock.patch("shutil.rmtree"), caplog.at_level(logging.INFO):
             result = self.run_cli_command(
                 "packages",

--- a/tests/test_configurations/test_constants.py
+++ b/tests/test_configurations/test_constants.py
@@ -22,9 +22,9 @@
 
 from pathlib import Path
 
-from aea.cli.packages import PackageManager
 from aea.configurations.constants import PACKAGES, SIGNING_PROTOCOL_WITH_HASH
 from aea.configurations.data_types import PackageId, PackageType, PublicId
+from aea.package_manager.v1 import PackageManagerV1
 
 from tests.conftest import ROOT_DIR
 
@@ -32,7 +32,7 @@ from tests.conftest import ROOT_DIR
 def test_signing_protocol_hash() -> None:
     """Test signing protocol"""
 
-    package_manager = PackageManager.from_dir(Path(ROOT_DIR, PACKAGES))
+    package_manager = PackageManagerV1.from_dir(Path(ROOT_DIR, PACKAGES))
     public_id = PublicId.from_str(SIGNING_PROTOCOL_WITH_HASH)
     package_id = PackageId(PackageType.PROTOCOL, public_id)
 


### PR DESCRIPTION
## Proposed changes

This PR makes newly introduced package manager functionality backwards compatible by introducing a base package manager class and using it as a base for two different versions of a package manager. 

`PackageManagerV0` follows the older format of `packages.json` and `PackageManagerV1` follows the new where we have introduced the separation for dev and third party packages. To utilise this change we have also extended the CLI command definition to make sure we choose the right package manager as per the content of the `packages.json`

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
