### PR TITLE
Raise when downloaded package is not an agent package on fetch command

### DIFF
--- a/aea/cli/fetch.py
+++ b/aea/cli/fetch.py
@@ -78,7 +78,7 @@ def fetch(
     ctx.registry_type = registry
     try:
         do_fetch(ctx, public_id, alias)
-    except NotAnAgentPacakge as e:
+    except NotAnAgentPackage as e:
         raise click.ClickException(str(e)) from e
 
 
@@ -164,7 +164,7 @@ def fetch_agent_ipfs(
     ctx.cwd = str(target_dir)
 
     if not Path(target_dir, DEFAULT_AEA_CONFIG_FILE).exists():
-        raise NotAnAgentPacakge(
+        raise NotAnAgentPackage(
             f"Downloaded packages at {target_dir} is not an agent package, please check hash"
         )
 
@@ -279,5 +279,5 @@ def fetch_mixed(
         fetch_agent(ctx, public_id, alias=alias, target_dir=target_dir)
 
 
-class NotAnAgentPacakge(Exception):
+class NotAnAgentPackage(Exception):
     """Raise when downloaded package is not an agent package."""

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -375,7 +375,7 @@ class TestFetchIPFS(BaseAEATestCase):
 
         with mock.patch(
             "aea.cli.fetch.get_default_remote_registry", return_value=REMOTE_IPFS
-        ), mock.patch.object(IPFSTool, "download"):
+        ), mock.patch.object(IPFSTool, "download", return_value="."):
 
             with pytest.raises(ClickException, match="is not an agent package"):
                 self.run_cli_command(

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -31,7 +31,7 @@ from click import ClickException
 
 import aea
 from aea.cli import cli
-from aea.cli.fetch import _is_version_correct, fetch_agent_locally
+from aea.cli.fetch import NotAnAgentPacakge, _is_version_correct, fetch_agent_locally
 from aea.cli.registry.settings import REMOTE_HTTP, REMOTE_IPFS
 from aea.cli.utils.context import Context
 from aea.configurations.base import PublicId
@@ -364,6 +364,20 @@ class TestFetchIPFS(BaseAEATestCase):
             with pytest.raises(
                 click.ClickException,
             ):
+                self.run_cli_command(
+                    "fetch",
+                    self.dummy_id,
+                    "--remote",
+                )
+
+    def test_not_an_agent_error(self) -> None:
+        """Test run."""
+
+        with mock.patch(
+            "aea.cli.fetch.get_default_remote_registry", return_value=REMOTE_IPFS
+        ), mock.patch.object(IPFSTool, "download"):
+
+            with pytest.raises(ClickException, match="is not an agent package"):
                 self.run_cli_command(
                     "fetch",
                     self.dummy_id,

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -31,7 +31,7 @@ from click import ClickException
 
 import aea
 from aea.cli import cli
-from aea.cli.fetch import NotAnAgentPacakge, _is_version_correct, fetch_agent_locally
+from aea.cli.fetch import _is_version_correct, fetch_agent_locally
 from aea.cli.registry.settings import REMOTE_HTTP, REMOTE_IPFS
 from aea.cli.utils.context import Context
 from aea.configurations.base import PublicId


### PR DESCRIPTION
## Proposed changes

This PR updates the agent fetching logic to raise proper exception when a downloaded package is not an agent package

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules