### PR TITLE
Add deprecation warning for `--aev` flag and make the usage of environment variables default

### DIFF
--- a/aea/cli/config.py
+++ b/aea/cli/config.py
@@ -28,6 +28,7 @@ from click.exceptions import ClickException
 from aea.cli.utils.constants import CONFIG_SUPPORTED_KEY_TYPES
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project, pass_ctx
+from aea.cli.utils.exceptions import aev_flag_depreaction
 from aea.configurations.manager import AgentConfigManager, VariableDoesNotExist
 from aea.configurations.validation import ExtraPropertiesError
 from aea.exceptions import AEAException
@@ -54,9 +55,13 @@ def config(click_context: click.Context) -> None:  # pylint: disable=unused-argu
 @pass_ctx
 def get(ctx: Context, apply_environment_variables: bool, json_path: str) -> None:
     """Get a field."""
+    if apply_environment_variables:
+        aev_flag_depreaction()
+
     try:
         agent_config_manager = AgentConfigManager.load(
-            ctx.cwd, apply_environment_variables
+            ctx.cwd,
+            substitude_env_vars=True,
         )
         value = agent_config_manager.get_variable(json_path)
     except (ValueError, AEAException) as e:
@@ -95,9 +100,13 @@ def set_command(
     type_: Optional[str],
 ) -> None:
     """Set a field."""
+    if apply_environment_variables:
+        aev_flag_depreaction()
+
     try:
         agent_config_manager = AgentConfigManager.load(
-            ctx.cwd, apply_environment_variables
+            ctx.cwd,
+            substitude_env_vars=True,
         )
 
         current_value = None

--- a/aea/cli/issue_certificates.py
+++ b/aea/cli/issue_certificates.py
@@ -26,6 +26,7 @@ from click import ClickException
 from aea.cli.utils.click_utils import password_option
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
+from aea.cli.utils.exceptions import aev_flag_depreaction
 from aea.cli.utils.loggers import logger
 from aea.cli.utils.package_utils import get_dotted_package_path_unified
 from aea.configurations.base import AgentConfig, PublicId
@@ -55,10 +56,13 @@ def issue_certificates(
     password: Optional[str],
 ) -> None:
     """Issue certificates for connections that require them."""
+    if apply_environment_variables:
+        aev_flag_depreaction()
+
     ctx = cast(Context, click_context.obj)
     agent_config_manager = AgentConfigManager.load(
         ctx.cwd,
-        substitude_env_vars=apply_environment_variables,
+        substitude_env_vars=True,
     )
     issue_certificates_(ctx.cwd, agent_config_manager, password=password)
 

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -32,6 +32,7 @@ from aea.cli.utils.click_utils import ConnectionsOption, password_option
 from aea.cli.utils.constants import AEA_LOGO, REQUIREMENTS
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
+from aea.cli.utils.exceptions import aev_flag_depreaction
 from aea.cli.utils.package_utils import list_available_packages
 from aea.configurations.base import ComponentType, PublicId
 from aea.configurations.manager import AgentConfigManager
@@ -117,6 +118,9 @@ def run(
     password: str,
 ) -> None:
     """Run the agent."""
+    if apply_environment_variables:
+        aev_flag_depreaction()
+
     if connection_ids and exclude_connection_ids:
         raise click.ClickException(
             "Please use only one of --connections or --exclude-connections, not both!"
@@ -148,8 +152,8 @@ def run(
             connection_ids,
             env_file,
             is_install_deps,
-            apply_environment_variables,
-            password,
+            apply_environment_variables=True,
+            password=password,
         )
 
 

--- a/aea/cli/utils/exceptions.py
+++ b/aea/cli/utils/exceptions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021 Valory AG
+#   Copyright 2021-2022 Valory AG
 #   Copyright 2018-2020 Fetch.AI Limited
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/aea/cli/utils/exceptions.py
+++ b/aea/cli/utils/exceptions.py
@@ -20,7 +20,18 @@
 
 """Module with exceptions of the aea cli."""
 
+from warnings import warn
+
+import click
+
 from aea.exceptions import AEAException
+
+
+def aev_flag_depreaction() -> None:
+    """Deprecation warning for `--aev` flag."""
+    message = "`--aev` flag is deprecated and will be removed in v2.0.0, usage of envrionment varibales is default now."
+    click.echo(message)
+    warn(message, DeprecationWarning, stacklevel=2)
 
 
 class AEAConfigException(AEAException):

--- a/tests/test_cli/test_run.py
+++ b/tests/test_cli/test_run.py
@@ -1598,7 +1598,7 @@ class TestExcludeConnection(AEATestCaseEmpty):
     def test_connection_excluded(self):
         """Test connection excluded."""
 
-        def raise_err(*args):
+        def raise_err(*args, **kwargs):
             raise Exception(args[1])
 
         with pytest.raises(Exception, match="^None$"):


### PR DESCRIPTION
## Proposed changes

This PR adds deprecation warning for `--aev` flag and make the usage of environment variables default

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
