### PR TITLE
Release v1.24.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,9 +7,12 @@ AEA:
 - Makes the usage of environment variables default
 - Extends `push-all` command to push only the development packages
 - Adds support for generating environment variable names if not provided by default
+- Changes log level from `debug` to `error` on `Exception` handling
+- Updates the configuration loader classes to make sure path string serialization is deterministic across the various platforms
 
 Test:
 - Fixes the tests skipped because of the wrongly configures ledger ID
+- Adds tests to check if path string serialization is deterministic across the various platforms
 
 Chores:
 - Updates `scripts/check_ipfs_hashes_pushed.py` to use new `packages.json` format

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,19 @@
 # Release History - open AEA
 
+## 1.24.0 (2022-11-15)
+
+AEA:
+- Adds deprecation warning for `--aev` flag
+- Makes the usage of environment variables default
+- Extends `push-all` command to push only the development packages
+- Adds support for generating environment variable names if not provided by default
+
+Test:
+- Fixes the tests skipped because of the wrongly configures ledger ID
+
+Chores:
+- Updates `scripts/check_ipfs_hashes_pushed.py` to use new `packages.json` format
+  
 ## 1.23.0 (2022-11-09)
 
 AEA:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-aea` are currently being suppo
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `1.23.x`   | :white_check_mark: |
-| `< 1.23.0` | :x:                |
+| `1.24.x`   | :white_check_mark: |
+| `< 1.24.0` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.23.0"
+__version__ = "1.24.0"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.24.0 "open-aea-cli-ipfs<2.0.0,>=1.23.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.24.0 "open-aea-cli-ipfs<2.0.0,>=1.24.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.23.0 "open-aea-cli-ipfs<2.0.0,>=1.23.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.24.0 "open-aea-cli-ipfs<2.0.0,>=1.23.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.23.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.24.0/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.23.0
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.24.0
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -111,7 +111,7 @@ $ export FOO=some_other_value
 $ aea run --aev
 ```
 
-The environment variable loading mechanism also supports the auto generation of the environment variable name from the json path if the variable name is not provided by default. The auto generated environment variable follows `{COMPONENT_TYPE}_{COMPONENT_NAME}_{JSON_PATH}` format to generate variable names
+The environment variable loading mechanism also supports the auto generation of the environment variable name from the `json` path if the variable name is not provided by default. The auto generated environment variable follows `{COMPONENT_TYPE}_{COMPONENT_NAME}_{JSON_PATH}` format to generate variable names
 
 Let's take following override as an example
 
@@ -126,7 +126,7 @@ config:
   foo: ${str:bar}
 ```
 
-Here we haven't define a environment variable name for the placeholder, this means when checking for the value the loading mechanism will generate the environment variable name for `foo` using it's json path. If we follow the format above, the environment variable name should be `CONNECTION_CONNECTION_A_CONFIG_FOO`
+Here we haven't define a environment variable name for the placeholder, this means when checking for the value the loading mechanism will generate the environment variable name for `foo` using it's `json` path. If we follow the format above, the environment variable name should be `CONNECTION_CONNECTION_A_CONFIG_FOO`
 
 ### Best practices when using overrides and suggestions 
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -8,6 +8,12 @@ Below we describe the additional manual steps required to upgrade between differ
 # Open AEA
 
 
+## `v1.23.0` to `v1.24.0`
+
+No backwards incompatible changes.
+
+Plugins from previous versions are not compatible anymore.
+
 ## `v1.22.0` to `v1.23.0`
 
 No backwards incompatible changes.

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.23.0
+RUN pip install --upgrade --force-reinstall aea[all]==1.24.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-benchmark",
-    version="1.23.0",
+    version="1.24.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.23.0",
+    version="1.24.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.23.0",
+    version="1.24.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.23.0",
+    version="1.24.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.23.0",
+    version="1.24.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.23.0 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.24.0 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.23.0 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.24.0 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.23.0"
+      template: "1.24.0"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.23.0"
+          template: "1.24.0"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -44,7 +44,7 @@ pip install open-aea[all]
 pip install open-aea-cli-ipfs
 ```
 ```
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.23.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.24.0/packages packages
 ```
 
 ``` bash

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.23.0
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.24.0
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.24.0

## Release details

AEA:
- Adds deprecation warning for `--aev` flag
- Makes the usage of environment variables default
- Extends `push-all` command to push only the development packages
- Adds support for generating environment variable names if not provided by default

Test:
- Fixes the tests skipped because of the wrongly configures ledger ID


Chores:
- Updates `scripts/check_ipfs_hashes_pushed.py` to use new `packages.json` format

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [ ] Lint and unit tests pass locally and in CI
- [ ] I have checked the fingerprint hashes are correct by running (`aea hash all` and `aea packages lock --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

## Further comments

Write here any other comment about the release, if any.
