### PR TITLE
Add support for validating and updating the hashes for package dependencies

### DIFF
--- a/aea/cli/ipfs_hash.py
+++ b/aea/cli/ipfs_hash.py
@@ -29,6 +29,7 @@ import sys
 import traceback
 from pathlib import Path
 from typing import Callable, Dict, Optional, Tuple, cast
+from warnings import warn
 
 import click
 
@@ -260,6 +261,16 @@ def generate_all(
     no_wrap: bool,
 ) -> None:
     """Generate IPFS hashes."""
+    message = (
+        "`aea hash all` command has been deprecated and will be removed on v2.0.0, "
+        "please use `aea packages lock` command to perform package hash updates"
+    )
+    warn(
+        message=message,
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    click.echo(message=message)
     packages_dir = Path(packages_dir).absolute()
     return_code = update_hashes(packages_dir, no_wrap, vendor=vendor)
     sys.exit(return_code)

--- a/aea/package_manager/base.py
+++ b/aea/package_manager/base.py
@@ -280,7 +280,7 @@ class BasePackageManager(ABC):
 
     @abstractmethod
     def get_package_hash(self, package_id: PackageId) -> Optional[str]:
-        """Sync local packages to the remote registry."""
+        """Return hash for the given package id."""
 
     @abstractmethod
     def sync(

--- a/docs/api/crypto/helpers.md
+++ b/docs/api/crypto/helpers.md
@@ -151,3 +151,13 @@ def hex_to_bytes_for_key(data: str) -> bytes
 
 Convert hex string to bytes with error handling.
 
+<a id="aea.crypto.helpers.generate_multiple_keys"></a>
+
+#### generate`_`multiple`_`keys
+
+```python
+def generate_multiple_keys(n: int, type_: str, password: Optional[str] = None, extra_entropy: Union[str, bytes, int] = "", file: Optional[str] = None) -> None
+```
+
+Generate n key pairs.
+

--- a/docs/api/package_manager/base.md
+++ b/docs/api/package_manager/base.md
@@ -23,12 +23,22 @@ Load a configuration, knowing the type and the path to the package root.
 
 the configuration object.
 
+<a id="aea.package_manager.base.DepedencyMismatchErrors"></a>
+
+## DepedencyMismatchErrors Objects
+
+```python
+class DepedencyMismatchErrors(Enum)
+```
+
+Dependency mismatch errors.
+
 <a id="aea.package_manager.base.BasePackageManager"></a>
 
 ## BasePackageManager Objects
 
 ```python
-class BasePackageManager()
+class BasePackageManager(ABC)
 ```
 
 AEA package manager
@@ -42,6 +52,46 @@ def __init__(path: Path) -> None
 ```
 
 Initialize object.
+
+<a id="aea.package_manager.base.BasePackageManager.iter_dependency_tree"></a>
+
+#### iter`_`dependency`_`tree
+
+```python
+def iter_dependency_tree() -> Iterator[PackageId]
+```
+
+Iterate dependency tree.
+
+<a id="aea.package_manager.base.BasePackageManager.check_dependencies"></a>
+
+#### check`_`dependencies
+
+```python
+def check_dependencies(configuration: PackageConfiguration) -> List[Tuple[PackageId, DepedencyMismatchErrors]]
+```
+
+Verify hashes for package dependecies againts the available hashes.
+
+<a id="aea.package_manager.base.BasePackageManager.update_public_id_hash"></a>
+
+#### update`_`public`_`id`_`hash
+
+```python
+def update_public_id_hash(public_id_str: str, package_type: str) -> str
+```
+
+Update public id hash from the latest available hashes.
+
+<a id="aea.package_manager.base.BasePackageManager.update_dependencies"></a>
+
+#### update`_`dependencies
+
+```python
+def update_dependencies(package_id: PackageId) -> None
+```
+
+Update dependency hashes to latest for a package.
 
 <a id="aea.package_manager.base.BasePackageManager.add_package"></a>
 
@@ -63,6 +113,16 @@ def package_path_from_package_id(package_id: PackageId) -> Path
 
 Get package path from the package id.
 
+<a id="aea.package_manager.base.BasePackageManager.calculate_hash_from_package_id"></a>
+
+#### calculate`_`hash`_`from`_`package`_`id
+
+```python
+def calculate_hash_from_package_id(package_id: PackageId) -> str
+```
+
+Calculate package hash from package id.
+
 <a id="aea.package_manager.base.BasePackageManager.update_package"></a>
 
 #### update`_`package
@@ -73,15 +133,16 @@ def update_package(package_id: PackageId) -> "BasePackageManager"
 
 Update package.
 
-<a id="aea.package_manager.base.BasePackageManager.get_available_package_hashes"></a>
+<a id="aea.package_manager.base.BasePackageManager.get_package_hash"></a>
 
-#### get`_`available`_`package`_`hashes
+#### get`_`package`_`hash
 
 ```python
-def get_available_package_hashes() -> PackageIdToHashMapping
+@abstractmethod
+def get_package_hash(package_id: PackageId) -> Optional[str]
 ```
 
-Returns a mapping object between available packages and their hashes
+Return hash for the given package id.
 
 <a id="aea.package_manager.base.BasePackageManager.sync"></a>
 

--- a/docs/api/package_manager/v0.md
+++ b/docs/api/package_manager/v0.md
@@ -35,6 +35,16 @@ def packages() -> OrderedDictType[PackageId, str]
 
 Returns mappings of package ids -> package hash
 
+<a id="aea.package_manager.v0.PackageManagerV0.get_package_hash"></a>
+
+#### get`_`package`_`hash
+
+```python
+def get_package_hash(package_id: PackageId) -> Optional[str]
+```
+
+Get package hash.
+
 <a id="aea.package_manager.v0.PackageManagerV0.sync"></a>
 
 #### sync
@@ -50,7 +60,7 @@ Sync local packages to the remote registry.
 #### update`_`package`_`hashes
 
 ```python
-def update_package_hashes() -> "PackageManagerV0"
+def update_package_hashes() -> "BasePackageManager"
 ```
 
 Update packages.json file.

--- a/docs/api/package_manager/v1.md
+++ b/docs/api/package_manager/v1.md
@@ -46,6 +46,36 @@ def third_party_packages() -> PackageIdToHashMapping
 
 Returns mappings of package ids -> package hash
 
+<a id="aea.package_manager.v1.PackageManagerV1.get_package_hash"></a>
+
+#### get`_`package`_`hash
+
+```python
+def get_package_hash(package_id: PackageId) -> Optional[str]
+```
+
+Get package hash.
+
+<a id="aea.package_manager.v1.PackageManagerV1.is_third_party_package"></a>
+
+#### is`_`third`_`party`_`package
+
+```python
+def is_third_party_package(package_id: PackageId) -> bool
+```
+
+Check if a package is third party package.
+
+<a id="aea.package_manager.v1.PackageManagerV1.is_dev_package"></a>
+
+#### is`_`dev`_`package
+
+```python
+def is_dev_package(package_id: PackageId) -> bool
+```
+
+Check if a package is third party package.
+
 <a id="aea.package_manager.v1.PackageManagerV1.sync"></a>
 
 #### sync


### PR DESCRIPTION
## Proposed changes

This PR extends the package manager API to validate and update hashes for the package dependencies. With this update the package manager will also update the hashes for third party hashes with a warning saying a hash change detected for a third party package.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
