### PR TITLE
Release v1.25.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,7 +50,7 @@ _Put an `x` in the boxes that apply._
 - [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [ ] I am making a pull request against the `main` branch (left side), from `develop`
 - [ ] Lint and unit tests pass locally and in CI
-- [ ] I have checked the fingerprint hashes are correct by running (`aea hash all` and `aea packages lock --check`)
+- [ ] I have checked the fingerprint hashes are correct by running (`aea packages lock --check`)
 - [ ] I have regenerated the latest API docs
 - [ ] I built the documentation and updated it with the latest changes
 - [ ] I have added an item in `HISTORY.md` for this release

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## 1.25.0 (2022-12-01)
 
 AEA:
-- Fixes the mechanism to convert the `json` path the environment variable string
+- Fixes the mechanism to convert the `json` path to environment variable string
 - Updates the process of agent subprocess termination to make sure we properly terminate agents across the various operating systems
 - Introduces `reraise_as_click_exception` to re-raise exceptions as `click.ClickExceptions` on command definitions
 - Extends `CliRunner` to allow usage of `capfd` to capture test output
@@ -13,7 +13,7 @@ AEA:
   - Update the hashes for third party packages with a warning
   - Update the dependency hashes when locking packages
   - Verifying the dependency hashes when verifying packages
-- Adds deprecation warning for `aea hash all` command
+- Adds deprecation warning for `aea hash all` command since the same functionality is now being provided by `aea packages lock` command
 
 Tests:
 - Updates `libp2p` tests to use `capsys` to read `stdout` instead of patching `sys.stdout`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,29 @@
 # Release History - open AEA
 
+## 1.25.0 (2022-12-01)
+
+AEA:
+- Fixes the mechanism to convert the `json` path the environment variable string
+- Updates the process of agent subprocess termination to make sure we properly terminate agents across the various operating systems
+- Introduces `reraise_as_click_exception` to re-raise exceptions as `click.ClickExceptions` on command definitions
+- Extends `CliRunner` to allow usage of `capfd` to capture test output
+- Introduce `generate_env_vars_recursively` method to auto generate the environment variable names for component overrides
+- Extends `aea generate-key` to support creating multiple keys
+- Extends the package manager API to
+  - Update the hashes for third party packages with a warning
+  - Update the dependency hashes when locking packages
+  - Verifying the dependency hashes when verifying packages
+- Adds deprecation warning for `aea hash all` command
+
+Tests:
+- Updates `libp2p` tests to use `capsys` to read `stdout` instead of patching `sys.stdout`
+- Re enables tests skipped with `# need remote registry` comment
+- Adds tests for package manager API
+
+Chores:
+- Updates the `tox` environment setting for unit tests to report duration of tests
+- Deprecates the usage of `aea hash all` command from the workflow
+
 ## 1.24.0 (2022-11-15)
 
 AEA:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@ AEA:
 - Updates the process of agent subprocess termination to make sure we properly terminate agents across the various operating systems
 - Introduces `reraise_as_click_exception` to re-raise exceptions as `click.ClickExceptions` on command definitions
 - Extends `CliRunner` to allow usage of `capfd` to capture test output
-- Introduce `generate_env_vars_recursively` method to auto generate the environment variable names for component overrides
+- Introduces `generate_env_vars_recursively` method to auto generate the environment variable names for component overrides
 - Extends `aea generate-key` to support creating multiple keys
 - Extends the package manager API to
   - Update the hashes for third party packages with a warning

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,6 @@ test-sub-p:
 
 .PHONY: hashes
 hashes:
-	python -m aea.cli hash all
-	python -m aea.cli hash all --packages-dir=./tests/data/packages
 	python -m aea.cli packages lock
 	python -m aea.cli --registry-path=./tests/data/packages packages lock
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-aea` are currently being suppo
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `1.24.x`   | :white_check_mark: |
-| `< 1.24.0` | :x:                |
+| `1.25.x`   | :white_check_mark: |
+| `< 1.25.0` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.24.0"
+__version__ = "1.25.0"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/aea/package_manager/v0.py
+++ b/aea/package_manager/v0.py
@@ -148,10 +148,14 @@ class PackageManagerV0(BasePackageManager):
                     package_id=package_id
                 )
                 if calculated_hash != expected_hash:
-                    failed = True
+                    # this update is required for further dependency checks for
+                    # packages where this package is a dependency
+                    self._packages[package_id] = calculated_hash
                     self._logger.error(
                         f"\nHash does not match for {package_id}\n\tCalculated hash: {calculated_hash}\n\tExpected hash: {expected_hash}"
                     )
+                    failed = True
+                    continue
 
                 dependencies_with_mismatched_hashes = self.check_dependencies(
                     configuration=configuration_obj,
@@ -167,7 +171,7 @@ class PackageManagerV0(BasePackageManager):
 
                         if failure == DepedencyMismatchErrors.HASH_DOES_NOT_MATCH:
                             self._logger.error(
-                                f"Dependency check failed; Hash does not match for {dep.without_hash()} in {package_id} configuration."
+                                f"Dependency check failed\nHash does not match for {dep.without_hash()} in {package_id} configuration."
                             )
                             continue
                     failed = True

--- a/aea/package_manager/v1.py
+++ b/aea/package_manager/v1.py
@@ -243,6 +243,12 @@ class PackageManagerV1(BasePackageManager):
                     continue
 
                 if calculated_hash != expected_hash:
+                    # this update is required for further dependency checks for
+                    # packages where this package is a dependency
+                    if self.is_third_party_package(package_id=package_id):
+                        self._third_party_packages[package_id] = calculated_hash
+                    if self.is_dev_package(package_id=package_id):
+                        self._dev_packages[package_id] = calculated_hash
                     self._logger.error(f"Hash does not match for {package_id}")
                     self._logger.error(f"\tCalculated hash: {calculated_hash}")
                     self._logger.error(f"\tExpected hash: {expected_hash}")
@@ -268,7 +274,7 @@ class PackageManagerV1(BasePackageManager):
 
                         if failure == DepedencyMismatchErrors.HASH_DOES_NOT_MATCH:
                             self._logger.error(
-                                f"Dependency check failed; Hash does not match for {dep.without_hash()} in {package_id} configuration."
+                                f"Dependency check failed\nHash does not match for {dep.without_hash()} in {package_id} configuration."
                             )
                             continue
 

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.25.0 "open-aea-cli-ipfs<2.0.0,>=1.24.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.25.0 "open-aea-cli-ipfs<2.0.0,>=1.25.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.24.0 "open-aea-cli-ipfs<2.0.0,>=1.24.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.25.0 "open-aea-cli-ipfs<2.0.0,>=1.24.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.24.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.25.0/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.24.0
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.25.0
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/creating-contracts.md
+++ b/docs/creating-contracts.md
@@ -79,7 +79,7 @@ from typing import Optional
 
 2. Fingerprint the contract so its hash matches our changes:
 ```bash
-aea hash all
+aea packages lock
 ```
 
 3. Proceed with the call as we did previously.

--- a/docs/ipfs_registry.md
+++ b/docs/ipfs_registry.md
@@ -22,7 +22,7 @@ Or
 
 ## Publish packages
 
-To publish a package on the IPFS registry, first run `aea hash all` to update the dependencies with the latest IPFS hashes. Then push the relevant packages using
+To publish a package on the IPFS registry, first run `aea packages lock` to update the dependencies with the latest IPFS hashes. Then push the relevant packages using
 
 `aea push COMPONENT_TYPE COMPONENT_PATH`
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -15,6 +15,8 @@ No backwards incompatible changes.
 
 Plugins from previous versions are not compatible anymore.
 
+The usage of `aea hash all` command has been deprecated and will be removed on `v2.0.0`, use `aea packages lock` command to perform hash updates for package dependencies.
+
 ## `v1.23.0` to `v1.24.0`
 
 No backwards incompatible changes.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,6 +7,13 @@ Below we describe the additional manual steps required to upgrade between differ
 
 # Open AEA
 
+### Upgrade guide
+
+## `v1.24.0` to `v1.25.0`
+
+No backwards incompatible changes.
+
+Plugins from previous versions are not compatible anymore.
 
 ## `v1.23.0` to `v1.24.0`
 
@@ -20,7 +27,6 @@ No backwards incompatible changes.
 
 Plugins from previous versions are not compatible anymore.
 
-### Upgrade guide
 
 This release introduces a new format for `packages.json` file, the older version is still supported but will be deprecated on `v2.0.0` so make sure to update your projects to use the new format.
 

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.24.0
+RUN pip install --upgrade --force-reinstall aea[all]==1.25.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,10 @@ nav:
         - Project: 'api/manager/project.md'
         - Helpers:  api/manager/helpers.md
         - Utils: 'api/manager/utils.md'
+      - Package Manager:
+        - Base: 'api/package_manager/base.md'
+        - Package Manager V0: 'api/package_manager/v0.md'
+        - Package Manager V1: 'api/package_manager/v1.md'
       - Protocols:
         - Base: 'api/protocols/base.md'
         - Dialogue:

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-benchmark",
-    version="1.24.0",
+    version="1.25.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.24.0",
+    version="1.25.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.24.0",
+    version="1.25.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.24.0",
+    version="1.25.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.24.0",
+    version="1.25.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.24.0 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.25.0 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.24.0 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.25.0 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.24.0"
+      template: "1.25.0"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.24.0"
+          template: "1.25.0"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/tests/test_cli/test_transfer.py
+++ b/tests/test_cli/test_transfer.py
@@ -19,6 +19,7 @@
 # ------------------------------------------------------------------------------
 """This test module contains the tests for commands in aea.cli.transfer module."""
 
+import platform
 import random
 import string
 from pathlib import Path
@@ -39,6 +40,12 @@ from aea.test_tools.test_cases import AEATestCaseEmpty
 
 from tests.common.utils import wait_for_condition
 from tests.conftest import MAX_FLAKY_RERUNS
+
+
+skip_fetchai_test_macos = pytest.mark.skipif(
+    condition=(platform.system() == "Darwin"),
+    reason="Continuously fails on CI",
+)
 
 
 class TestCliTransferFetchAINetwork(AEATestCaseEmpty):
@@ -94,6 +101,7 @@ class TestCliTransferFetchAINetwork(AEATestCaseEmpty):
             wallet = get_wallet_from_agent_config(agent_config, password=self.PASSWORD)
             return int(try_get_balance(agent_config, wallet, self.LEDGER_ID))
 
+    @skip_fetchai_test_macos
     @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)
     def test_integration(self):
         """Perform integration tests of cli transfer command with real transfer."""

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -44,7 +44,7 @@ pip install open-aea[all]
 pip install open-aea-cli-ipfs
 ```
 ```
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.24.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.25.0/packages packages
 ```
 
 ``` bash

--- a/tests/test_package_manager/test_v0.py
+++ b/tests/test_package_manager/test_v0.py
@@ -49,7 +49,7 @@ class TestPackageManagerV0(BaseAEATestCase):
     ) -> None:
         """Setup test."""
 
-        # the current `packages.json` in `packages/` directory follows the v1 
+        # the current `packages.json` in `packages/` directory follows the v1
         # format so we will have to load it and convert it to v0 format
         packages_v1 = json.loads(PACKAGE_JSON_FILE.read_text(encoding="utf-8"))
 

--- a/tests/test_package_manager/test_v0.py
+++ b/tests/test_package_manager/test_v0.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from unittest import mock
 
 from aea.package_manager.v0 import PackageManagerV0
+from aea.protocols.generator.common import INIT_FILE_NAME
 from aea.test_tools.test_cases import BaseAEATestCase
 
 from tests.test_package_manager.test_base import (
@@ -130,16 +131,23 @@ class TestVerifyFailure(BaseAEATestCase):
         pm = PackageManagerV0.from_dir(self.packages_dir_path)
         assert pm.verify() == 0
 
-        packages[EXAMPLE_PACKAGE_ID.to_uri_path] = DUMMY_PACKAGE_HASH
-        packages_json_file.write_text(json.dumps(obj=packages))
+        # updating the `packages/open_aea/protocols/signing/__init__.py` file
+        init_file = (
+            pm.package_path_from_package_id(package_id=EXAMPLE_PACKAGE_ID)
+            / INIT_FILE_NAME
+        )
+        init_file.write_text("")
 
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.ERROR), mock.patch(
+            "aea.package_manager.v0.check_fingerprint",
+            return_value=True,
+        ):
             pm = PackageManagerV0.from_dir(self.packages_dir_path)
 
             assert pm.verify() == 1
             assert f"Hash does not match for {EXAMPLE_PACKAGE_ID}" in caplog.text
             assert (
-                f"Dependency check failed; Hash does not match for {EXAMPLE_PACKAGE_ID}"
+                f"Dependency check failed\nHash does not match for {EXAMPLE_PACKAGE_ID}"
                 in caplog.text
             )
 

--- a/tox.ini
+++ b/tox.ini
@@ -190,13 +190,6 @@ skip_install = True
 deps =
 commands = {toxinidir}/scripts/check_copyright_notice.py --check
 
-[testenv:hash-all]
-skipsdist = True
-usedevelop = True
-commands =
-    pip install {toxinidir}[all]
-    aea hash all
-    aea hash all --packages-dir=./tests/data/packages
 
 [testenv:hash-check]
 skipsdist = True

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.24.0
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.25.0
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.25.0

## Release details

AEA:
- Fixes the mechanism to convert the `json` path the environment variable string
- Updates the process of agent subprocess termination to make sure we properly terminate agents across the various operating systems
- Introduces `reraise_as_click_exception` to re-raise exceptions as `click.ClickExceptions` on command definitions
- Extends `CliRunner` to allow usage of `capfd` to capture test output
- Introduce `generate_env_vars_recursively` method to auto generate the environment variable names for component overrides
- Extends `aea generate-key` to support creating multiple keys
- Extends the package manager API to
  - Update the hashes for third party packages with a warning
  - Update the dependency hashes when locking packages
  - Verifying the dependency hashes when verifying packages
- Adds deprecation warning for `aea hash all` command

Tests:
- Updates `libp2p` tests to use `capsys` to read `stdout` instead of patching `sys.stdout`
- Re enables tests skipped with `# need remote registry` comment
- Adds tests for package manager API

Chores:
- Updates the `tox` environment setting for unit tests to report duration of tests
- Deprecates the usage of `aea hash all` command from the workflow

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [ ] Lint and unit tests pass locally and in CI
- [ ] I have checked the fingerprint hashes are correct by running (`aea hash all` and `aea packages lock --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.