### PR TITLE
[v1.26.0] Add support for appending test coverage on `aea test` command

### DIFF
--- a/tests/test_cli/test_test.py
+++ b/tests/test_cli/test_test.py
@@ -337,3 +337,30 @@ class TestPackageTestByPath(BaseAEATestCommand):
                 str(package_dirpath),
             )
             assert result.exit_code == OK_PYTEST_EXIT_CODE
+
+
+@_parametrize_class
+class TestPackageTestByPathWithCov(BaseAEATestCommand):
+    """Test that the command 'aea test by-path path-to-package' works as expected (non-empty test suite)."""
+
+    @pytest.mark.parametrize("package_type", list(ComponentType))
+    def test_run(
+        self, package_type: ComponentType, mock_sys_modules, *_mocks: Any
+    ) -> None:
+        """Assert that the exit code is equal to 0 (tests are run successfully)."""
+        self._configure_package_for_testing(package_type)
+        test_package_name = self._get_dummy_package_name(package_type)
+        package_dirpath = self.dummy_package_dirpath(package_type, test_package_name)
+        with mock_pytest_main():
+            result = self.run_test_command(
+                "--cov",
+                "by-path",
+                str(package_dirpath),
+            )
+            assert result.exit_code == OK_PYTEST_EXIT_CODE
+
+            agent_path = self.t / self.agent_name
+
+            assert (agent_path / "coverage.xml").exists()
+            assert (agent_path / "htmlcov").exists()
+            assert (agent_path / ".coverage").exists()

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,7 @@ commands =
     ; for some reason tox installs aea without respect to the dependencies version specified in setup.py. at least in CI env
     ; so install current aea in a normal way
     {[commands-local-install]commands}
-    aea test packages --durations=0 {posargs}
+    aea test --cov --append packages --durations=0 {posargs}
 
 [test-plugins]
 deps = 


### PR DESCRIPTION
## Proposed changes

This PR adds support for appending the test coverage and enables test coverage on packages

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

