### PR TITLE
Fix: comparison `PackageVersion` `"any"` & `"latest"`

### DIFF
--- a/tests/test_configurations/test_data_types.py
+++ b/tests/test_configurations/test_data_types.py
@@ -21,9 +21,9 @@
 
 import copy
 import operator
-from typing import Tuple
 from itertools import permutations
 from math import isnan
+from typing import Tuple
 
 import pytest
 from hypothesis import assume, given
@@ -140,7 +140,9 @@ def test_any_and_latest_equal(version_like: str):
     assert not version_a < version_b
 
 
-@pytest.mark.parametrize("version_like_pair", permutations(["any", "latest", "0.1.0"], 2))
+@pytest.mark.parametrize(
+    "version_like_pair", permutations(["any", "latest", "0.1.0"], 2)
+)
 def test_any_latest_and_numeric_unequal(version_like_pair: Tuple[str]):
     """Test special version types "any" and "latest" when equal."""
 


### PR DESCRIPTION
## Proposed changes

This PR addresses the comparison operator logic concerning `PackageVersion` "special" types, `"any"` and `"latest"`, whose logical comparison with numeric version types is problematic (see https://github.com/valory-xyz/open-aea/pull/448#discussion_r1025388104). I will explain this using (pseudo) code to accommodate the reader, and explain the solution chosen.

when comparing `a` and `b` (where `.version` can be considered some numeric fixed-size tuple), one might reason as follows:
- `__eq__`:
    ```
    if a.is_any or b.is_any or (a.is_latest and b.is_latest):
        return True
    if self.is_latest or other.is_latest:
        return ...
    return a.version == b.version
    ```
- `__lt__`:
    ```
    if a.is_any or b.is_any:
        return False
    if a.is_latest or b.is_latest:
        return not self.is_latest
    return a.version < b.version
    ```

other comparison operators do not need to be reasoned about (see: [functools.total_ordering](https://docs.python.org/3/library/functools.html#functools.total_ordering)).

However,
1. Comparison of `"latest"` and a numeric version type is problematic: how do we determine whether a version is the latest version? Do we query the available local data, should we check a remote repository? Currently, `is_latest` is a property that simply returns whether `._version` is `"latest"`. Is does not treat it as a property of a specific version, that is, version `0.1.0` might be the actual latest, the current implementation will still return `False`. Changing this would constitute a functional and further backwards incompatible change. 
2. Though may reason that `__eq__` with `"any"` should always return `True`, and `__lt__` return `False`, this violates the law of transitivity (e.g. if `0.1.0 == "any"` and `0.2.0 == "any"` it follows that `0.1.0 == 0.2.0`). Note that this will make sorting results dependent on the algorithm and/or initial conditions, which they should not be.

Moreover, the `"any"` and `"latest"` tags are currently not used in any place where they are used in comparisons; it does not appear to be relevant for their functional purpose. Hence the chosen solution:
- When comparing using `__eq__` we return `False` when comparing any pair of `"any", "false", <some_numeric_version>`. This is consistent with other comparison behaviour in python (e.g. equality comparison of integer and string will always return `False`.)
- when comparing using `__lt__` we raise a `TypeError`. The same reasoning as above applies.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
