### PR TITLE
[v1.27.0] cli test packages command --all flag added. dev by default

### DIFF
--- a/aea/package_manager/v1.py
+++ b/aea/package_manager/v1.py
@@ -22,6 +22,7 @@
 import json
 import traceback
 from collections import OrderedDict
+from itertools import chain
 from pathlib import Path
 from typing import Dict, Optional
 from typing import OrderedDict as OrderedDictType
@@ -75,6 +76,13 @@ class PackageManagerV1(BasePackageManager):
         """Returns mappings of package ids -> package hash"""
 
         return self._third_party_packages
+
+    @property
+    def all_packages(self) -> PackageIdToHashMapping:
+        """Return all packages."""
+        return OrderedDict(
+            chain(self.dev_packages.items(), self.third_party_packages.items())
+        )
 
     def get_package_hash(self, package_id: PackageId) -> Optional[str]:
         """Get package hash."""


### PR DESCRIPTION
## Proposed changes

cli test packages command --all flag added. dev by default

## Fixes

https://github.com/valory-xyz/open-autonomy/pull/1676#discussion_r1051874504


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...


DELETE INCLUSIVE THIS AND BELOW FOR STANDARD PR
------

## Release summary

Version number: [e.g. 1.0.1]

## Release details

Describe in short the main changes with the new release.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [ ] Lint and unit tests pass locally and in CI
- [ ] I have checked the fingerprint hashes are correct by running (`aea packages lock --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

## Further comments

Write here any other comment about the release, if any.
