### PR TITLE
Release/v1.27.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,25 @@
 # Release History - open AEA
 
+## 1.27.0 (2022-12-27)
+
+AEA:
+- Adds auto-generated protobuf `*_pb2.py` and `*_pb2_*.py` files to `coveragerc` ignore template for aea test command.
+- Fixes comparison operators ` __eq__`, `__ne__`, `__lt__`, `__le__`, `__gt__`, `__ge__` for multiple classes including `PackageVersion`.
+- Adds support to `test packages` command for the `--all` flag and switches default behaviour to only run tests on `dev` packages.
+- Fixes miscellaneous issues on base test classes and adds consistency checks via meta classes.
+
+Plugins:
+- Updates `open-aea-cli-ipfs` to retry in case an IPFS download fails
+
+Tests:
+- Fills coverage gaps on core `aea`
+- Fills coverage gaps on multiple packages
+- Fills coverage gaps on all plugins
+
+Chores:
+- Merges the coverage checks with unit tests and removes the extra test coverage CI run.
+- Cleans up release flow.
+
 ## 1.26.0 (2022-12-15)
 
 AEA:

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,6 @@ test-sub-p:
 	pytest -rfE --doctest-modules aea packages/valory/connections packages/valory/protocols packages/fetchai/connections packages/fetchai/protocols packages/fetchai/skills tests/test_packages/test_$(tdir) --cov=packages.fetchai.$(dir) --cov-report=html --cov-report=xml --cov-report=term-missing --cov-report=term  --cov-config=.coveragerc
 	find . -name ".coverage*" -not -name ".coveragerc" -exec rm -fr "{}" \;
 
-.PHONY: hashes
-hashes:
-	python -m aea.cli packages lock
-	python -m aea.cli --registry-path=./tests/data/packages packages lock
-
 .PHONY: test-all
 test-all:
 	tox
@@ -167,7 +162,6 @@ security:
 generators:
 	rm -rf packages/fetchai/connections/stub/input_file
 	tox -e fix-copyright
-	tox -e hash-all
 	tox -e lock-packages
 	tox -e generate-all-protocols
 	tox -e generate-api-documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-aea` are currently being suppo
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `1.26.x`   | :white_check_mark: |
-| `< 1.26.0` | :x:                |
+| `1.27.x`   | :white_check_mark: |
+| `< 1.27.0` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.26.0"
+__version__ = "1.27.0"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.26.0 "open-aea-cli-ipfs<2.0.0,>=1.26.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.27.0 "open-aea-cli-ipfs<2.0.0,>=1.27.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.26.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.27.0/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.26.0
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.27.0
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -11,6 +11,16 @@ Below we describe the additional manual steps required to upgrade between differ
 
 ## `v1.25.0` to `v1.26.0`
 
+Multiple small backwards incompatible changes:
+- `BaseContractTestCase` no longer sets a default `path_to_contract` and `ledger_identifier`. The user is expected to set these and an exception is thrown if classes are defined without these.
+- `BaseContractTestCase` had wrongly defined `setup`. This is now changed to `setup_class`.
+- `BaseSkillTestCase` no longer sets a default `path_to_skill`. The user is expected to set this and an exception is thrown if classes are defined without this.
+- Comparison operators were fixed for multiple custom classes. Some edge cases will behave differently. Consult [#428](https://github.com/valory-xyz/open-aea/pull/428) and related PRs.
+
+Plugins from previous versions are not compatible anymore.
+
+## `v1.25.0` to `v1.26.0`
+
 No backwards incompatible changes.
 
 Plugins from previous versions are not compatible anymore.

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.26.0
+RUN pip install --upgrade --force-reinstall aea[all]==1.27.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -208,6 +208,7 @@ nav:
           - Dialogues: 'api/protocols/signing/dialogues.md'
           - Message: 'api/protocols/signing/message.md'
           - Serialization: 'api/protocols/signing/serialization.md'
+          - Test: 'api/protocols/signing/tests/test_signing.md'
       - Registries:
         - Base: 'api/registries/base.md'
         - Filter: 'api/registries/filter.md'
@@ -234,6 +235,7 @@ nav:
             - Exceptions: 'api/plugins/aea_cli_ipfs/exceptions.md'
             - Registry: 'api/plugins/aea_cli_ipfs/registry.md'
             - Utils: 'api/plugins/aea_cli_ipfs/ipfs_utils.md'
+            - Test Tools: 'api/plugins/aea_cli_ipfs/test_tools/fixture_helpers.md'
           - Benchmark:
               - Core: api/plugins/aea_cli_benchmark/core.md
               - Utils:  api/plugins/aea_cli_benchmark/utils.md
@@ -283,6 +285,7 @@ nav:
         - Ledger:
           - Cosmos:
             - API: 'api/plugins/aea_ledger_cosmos/cosmos.md'
+            - HashFuncs: 'api/plugins/aea_ledger_cosmos/hashfuncs.md'
           - Ethereum:
             - API: 'api/plugins/aea_ledger_ethereum/ethereum.md'
             - Constants: api/plugins/aea_ledger_ethereum/test_tools/constants.md
@@ -292,6 +295,7 @@ nav:
             - API: 'api/plugins/aea_ledger_fetchai/fetchai.md'
             - Constants: api/plugins/aea_ledger_fetchai/test_tools/constants.md
             - Docker Images: api/plugins/aea_ledger_fetchai/test_tools/docker_images.md
+            - HashFuncs: 'api/plugins/aea_ledger_fetchai/hashfuncs.md'
             - Helper: 'api/plugins/aea_ledger_fetchai/_cosmos.md'
   - Registries:
     - IPFS: ipfs_registry.md

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-benchmark",
-    version="1.26.0",
+    version="1.27.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.26.0",
+    version="1.27.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.26.0",
+    version="1.27.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.26.0",
+    version="1.27.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.26.0",
+    version="1.27.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",

--- a/scripts/RELEASE_PROCESS.md
+++ b/scripts/RELEASE_PROCESS.md
@@ -1,48 +1,40 @@
 
 # Release Process from develop to main
 
-1. Make sure all tests pass, coverage is at 100% and the local branch is in a clean state (nothing to commit). Make sure you have a clean develop virtual environment.
+1. Make sure you have a clean develop virtual environment (`make new_env`). Make sure all tests pass, coverage is at 100% and the local branch is in a clean state (nothing to commit after running `make formatters`, `make code-checks` and `make generators`).
 
-2. Determine the next AEA version
-   Create new release branch named "feature/release-{new-version}, switch to this branch"
-   Run `python scripts/bump_aea_version.py --new-version NEW_VERSION_HERE`. Commit if satisfied.
+2. Determine the next AEA version: Create new release branch named "feature/release-{new-version}, switch to this branch and run `python scripts/bump_aea_version.py --new-version NEW_VERSION_HERE`. Commit if satisfied.
 
 3. Bump plugin versions if necessary by running `python scripts/update_plugin_versions.py --update "PLUGIN_NAME,NEW_VERSION"`. Commit if satisfied.
 
-4. Check the protocols are up-to-date by running `aea generate-all-protocols --check-clean`. Commit if changes occurred. Do the same for test protocols using `aea generate-all-protocols tests/data/packages --check-clean`
+4. [CURRENTLY SKIPPED] Bump all the packages to their latest versions by running `python scripts/update_package_versions.py`.
 
-5. [CURRENTLY SKIPPED] Bump all the packages to their latest versions by running `python scripts/update_package_versions.py`.
+5. Update the package and dependency hashes, protocols, as well as docs using `make generators`. Commit if changes occurred.
 
-6. Update the package and dependency hashes using `make hashes`. Commit if changes occurred.
+6. Ensure all links are configured `tox -e docs-serve`. Commit if satisfied.
 
-7. Check the package upgrades are correct by running `python -m aea.cli check-packages` and `python scripts/check_package_versions_in_docs.py`. Commit if satisfied.
+7. Write release notes and place them in `HISTORY.md`. Add upgrading tips in `upgrading.md`. If necessary, adjust version references in `SECURITY.md`. Commit if satisfied.
 
-8. Check the docs are up-to-date by running `tox -e generate-api-documentation`, `python scripts/check_doc_ipfs_hashes.py --fix` and `python scripts/check_doc_links.py`. Ensure all links are configured `mkdocs serve`. Commit if satisfied.
+8. Run spell checker `./scripts/spell-check.sh`. Run `pylint --disable all --enable spelling ...`. Commit if required.
 
-9. Ensure the signing protocol hash in open-aea is updated: `tests/test_configurations/test_constants.py::test_signing_protocol_hash`
+9. Open PRs and merge into develop. Then open develop to main PR and merge it.
 
-10. Write release notes and place them in `HISTORY.md`. Add upgrading tips in `upgrading.md`. If necessary, adjust version references in `SECURITY.md`. Commit if satisfied.
+10. Tag version on main.
 
-11. Run spell checker `./scripts/spell-check.sh`. Run `pylint --disable all --enable spelling ...`. Commit if required.
+11. Pull main, make a clean environment (`pipenv --rm` and `pipenv --python 3.10` and `pipenv shell`) and create distributions: `make dist`.
 
-12. Open PRs and merge into develop. Then open develop to main PR and merge it.
-
-13. Tag version on main.
-
-14. Pull main, make a clean environment (`pipenv --rm` and `pipenv --python 3.10` and `pipenv shell`) and create distributions: `make dist`.
-
-15. Publish to PyPI with twine: `pip install twine` and `twine upload dist/*`. Optionally, publish to Test-PyPI with twine:
+12. Publish to PyPI with twine: `pip install twine` and `twine upload dist/*`. Optionally, publish to Test-PyPI with twine:
 `twine upload --repository-url https://test.pypi.org/legacy/ dist/*`.
 
-16. Repeat 14. & 15. for each plugin (use `python setup.py sdist bdist_wheel` instead of `make dist`).
+13. Repeat 14. & 15. for each plugin (use `python setup.py sdist bdist_wheel` instead of `make dist`).
 
-17. Make clean environment and install release from PyPI: `pip install open-aea[all] --no-cache`.
+14. Make clean environment and install release from PyPI: `pip install open-aea[all] --no-cache`.
 
-18. Publish the latest packages to the IPFS registry using `aea init --reset --author valory --ipfs --remote` and `aea push-all`. If necessary, run it several times until all packages are updated.
+15. Publish the latest packages to the IPFS registry using `aea init --reset --author valory --ipfs --remote` and `aea push-all`. If necessary, run it several times until all packages are updated.
 
-19. Build the release images using `skaffold build -p release` which will also publish them to Docker Hub. This builds with no cache so to ensure replicable builds.
+16. Build the release images using `skaffold build -p release` which will also publish them to Docker Hub. This builds with no cache so to ensure replicable builds.
 
-20. Tag the latest images using `skaffold build -p release-latest` which will also publish them to Docker Hub.
+17. Tag the latest images using `skaffold build -p release-latest` which will also publish them to Docker Hub.
 
 
 If something goes wrong and only needs a small fix do `LAST_VERSION.post1` as version, apply fixes, push again to PyPI.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.26.0 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.27.0 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.26.0 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.27.0 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.26.0"
+      template: "1.27.0"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.26.0"
+          template: "1.27.0"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -44,7 +44,7 @@ pip install open-aea[all]
 pip install open-aea-cli-ipfs
 ```
 ```
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.26.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.27.0/packages packages
 ```
 
 ``` bash

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 ; we set the associated flag (e.g. for linting we don't need
 ; the package installation).
 [tox]
-envlist = bandit, safety, black, black-check, isort, isort-check, fix-copyright, check-copyright, hash-check, docs, flake8, liccheck, mypy, pylint, vulture, {plugins-,}py{3.7,3.8,3.9,3.10,3.10-cov}, dependencies-check, package-version-checks, package-dependencies-checks, plugins_deps, fix-doc-hashes, check-doc-links-hashes, check-generate-all-protocols, spell-check, generate-api-documentation
+envlist = bandit, safety, black, black-check, isort, isort-check, fix-copyright, check-copyright, hash-check, docs, flake8, liccheck, mypy, pylint, vulture, {plugins-,}py{3.7,3.8,3.9,3.10,3.10-cov}, dependencies-check, package-version-checks, lock-packages, package-dependencies-checks, plugins_deps, fix-doc-hashes, check-doc-links-hashes, check-generate-all-protocols, spell-check, generate-api-documentation
 ; when running locally we don't want to fail for no good reason
 skip_missing_interpreters = true
 
@@ -328,6 +328,7 @@ deps =
 commands = pip install {toxinidir}[all]
            python -m pip install --no-deps file://{toxinidir}/plugins/aea-cli-ipfs
            aea generate-all-protocols --check-clean
+           aea generate-all-protocols tests/data/packages --check-clean
 
 [testenv:spell-check]
 whitelist_externals = mdspell

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.26.0
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.27.0
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.27.0

## Release details

AEA:
- Adds auto-generated protobuf `*_pb2.py` and `*_pb2_*.py` files to `coveragerc` ignore template for aea test command.
- Fixes comparison operators ` __eq__`, `__ne__`, `__lt__`, `__le__`, `__gt__`, `__ge__` for multiple classes including `PackageVersion`.
- Adds support to `test packages` command for the `--all` flag and switches default behaviour to only run tests on `dev` packages.
- Fixes miscellaneous issues on base test classes and adds consistency checks via meta classes.

Plugins:
- Updates `open-aea-cli-ipfs` to retry in case an IPFS download fails

Tests:
- Fills coverage gaps on core `aea`
- Fills coverage gaps on multiple packages
- Fills coverage gaps on all plugins

Chores:
- Merges the coverage checks with unit tests and removes the extra test coverage CI run.
- Cleans up release flow.

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [x] Lint and unit tests pass locally and in CI
- [x] I have checked the fingerprint hashes are correct by running (`aea packages lock --check`)
- [x] I have regenerated the latest API docs
- [x] I built the documentation and updated it with the latest changes
- [x] I have added an item in `HISTORY.md` for this release
- [x] I bumped the version number in the `aea/__version__.py` file.
- [x] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

## Further comments

-