### PR TITLE
fix: ipfs download move to target dir

### DIFF
--- a/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
+++ b/plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_utils.py
@@ -341,9 +341,9 @@ class IPFSTool:
                     error_msg = f"Expected a single directory, found: {paths}"
                     raise DownloadError(error_msg)
                 package_path = paths.pop()
-
-            package_path.rename(target_dir / package_path.name)
-            return str(package_path)
+            # move not rename cause can be on different filesystems
+            shutil.move(package_path, target_dir / package_path.name)
+            return str(target_dir / package_path.name)
 
         target_dir = Path(target_dir)
         target_dir.mkdir(exist_ok=True, parents=True)

--- a/plugins/aea-cli-ipfs/tests/test_utils.py
+++ b/plugins/aea-cli-ipfs/tests/test_utils.py
@@ -224,6 +224,8 @@ def test_tool_download() -> None:
         "pathlib.Path.iterdir", return_value=[]
     ), patch(
         "shutil.rmtree"
+    ), patch(
+        "shutil.move"
     ):
         with pytest.raises(DownloadError, match="Failed to download: some"):
             with patch("time.sleep"):
@@ -232,4 +234,4 @@ def test_tool_download() -> None:
 
         client_mock.get = Mock()
 
-        ipfs_tool.download("some", tmp_dir, attempts=5)
+        assert ipfs_tool.download("some", tmp_dir, attempts=5) == tmp_dir


### PR DESCRIPTION
## Proposed changes

fix: ipfs download move to target dir

## Fixes

small fix after refactoring at https://github.com/valory-xyz/open-aea/pull/480/files

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...


DELETE INCLUSIVE THIS AND BELOW FOR STANDARD PR
------

## Release summary

Version number: [e.g. 1.0.1]

## Release details

Describe in short the main changes with the new release.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [ ] Lint and unit tests pass locally and in CI
- [ ] I have checked the fingerprint hashes are correct by running (`aea packages lock --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

## Further comments

Write here any other comment about the release, if any.
