### PR TITLE
chore: bump open-aea-cli-ipfs to 1.27.0.post2

### DIFF
--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.27.0 "open-aea-cli-ipfs<2.0.0,>=1.27.0.post1"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.27.0 "open-aea-cli-ipfs<2.0.0,>=1.27.0.post2"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.27.0.post1",
+    version="1.27.0.post2",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",


### PR DESCRIPTION
## Proposed changes

Post release for open-aea-cli-ipfs to v1.27.0.post2