### PR TITLE
Release v1.28.0.post1

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -365,6 +365,7 @@ output_file
 gitleaks
 1.18.0.post1
 aea-cli-ipfs
+1.28.0.post1
  - docs/creating-contracts.md
 ABI
 ERC20

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,18 @@
 # Release History - open AEA
 
+
+## 1.28.0.post1 (2023-01-16)
+
+AEA:
+- Fixes the module import issue on the `aea test` command by removing the usage of spawned process to run the pytest command
+
+Plugins:
+- Pins proper version for cosmos plugin on the ledger plugin
+- Updates the `LedgerApi.update_with_gas_estimation` method to raise instead of logging the error if specified by the user
+
+Chores:
+- Pins `pywin32` to `>=304`
+
 ## 1.28.0 (2023-01-11)
 
 AEA:

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.28.0"
+__version__ = "1.28.0.post1"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.28.0.post1 "open-aea-cli-ipfs<2.0.0,>=1.28.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.28.0.post1 "open-aea-cli-ipfs<2.0.0,>=1.28.0.post1"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.28.0 "open-aea-cli-ipfs<2.0.0,>=1.28.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.28.0.post1 "open-aea-cli-ipfs<2.0.0,>=1.28.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.28.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.28.0.post1/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.28.0
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.28.0.post1
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,7 +9,11 @@ Below we describe the additional manual steps required to upgrade between differ
 
 ### Upgrade guide
 
-## `v1.26.0` to `v1.27.0`
+## `v1.28.0` to `v1.28.0.post1`
+
+- No backwards incompatible changes
+
+## `v1.27.0` to `v1.28.0`
 
 One breaking change
 

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.28.0
+RUN pip install --upgrade --force-reinstall aea[all]==1.28.0.post1
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-benchmark",
-    version="1.28.0",
+    version="1.28.0.post1",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.28.0",
+    version="1.28.0.post1",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.28.0",
+    version="1.28.0.post1",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.28.0",
+    version="1.28.0.post1",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.28.0",
+    version="1.28.0.post1",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.28.0 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.28.0.post1 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.28.0 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.28.0.post1 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.28.0"
+      template: "1.28.0.post1"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.28.0"
+          template: "1.28.0.post1"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -44,7 +44,7 @@ pip install open-aea[all]
 pip install open-aea-cli-ipfs
 ```
 ```
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.28.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.28.0.post1/packages packages
 ```
 
 ``` bash

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.28.0
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.28.0.post1
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.28.0.post1

## Release details

AEA:
- Fixes the module import issue on the `aea test` command by removing the usage of spawned process to run the pytest command

Plugins:
- Pins proper version for cosmos plugin on the ledger plugin
- Updates the `LedgerApi.update_with_gas_estimation` method to raise instead of logging the error if specified by the user

Chores:
- Pins `pywin32` to `>=304`
## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [ ] Lint and unit tests pass locally and in CI
- [ ] I have checked the fingerprint hashes are correct by running (`aea packages lock --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

## Further comments

Write here any other comment about the release, if any.
