### PR TITLE
use shutil.copytree isntead of outdated distutils.dir_util

### DIFF
--- a/aea/cli/fetch.py
+++ b/aea/cli/fetch.py
@@ -20,7 +20,6 @@
 """Implementation of the 'aea fetch' subcommand."""
 import os
 import shutil
-from distutils.dir_util import copy_tree  # pylint: disable=deprecated-module
 from pathlib import Path
 from typing import Optional, Union, cast
 
@@ -246,7 +245,7 @@ def fetch_agent_locally(
         os.makedirs(target_path)  # pragma: nocover
 
     ctx.clean_paths.append(target_path)
-    copy_tree(source_path, target_path)
+    shutil.copytree(source_path, target_path, dirs_exist_ok=True)
 
     ctx.cwd = target_path
     try_to_load_agent_config(ctx)

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -66,7 +66,7 @@ class FetchAgentLocallyTestCase(TestCase):
 
     @mock.patch("aea.cli.fetch._is_version_correct", return_value=True)
     @mock.patch("aea.cli.fetch.os.path.exists", return_value=False)
-    @mock.patch("aea.cli.fetch.copy_tree")
+    @mock.patch("shutil.copytree")
     def test_fetch_agent_locally_positive(self, copy_tree, *mocks):
         """Test for fetch_agent_locally method positive result."""
         ctx = ContextMock()
@@ -76,7 +76,7 @@ class FetchAgentLocallyTestCase(TestCase):
 
     @mock.patch("aea.cli.fetch._is_version_correct", return_value=True)
     @mock.patch("aea.cli.fetch.os.path.exists", return_value=True)
-    @mock.patch("aea.cli.fetch.copy_tree")
+    @mock.patch("shutil.copytree")
     def test_fetch_agent_locally_already_exists(self, *mocks):
         """Test for fetch_agent_locally method agent already exists."""
         ctx = ContextMock()
@@ -86,7 +86,7 @@ class FetchAgentLocallyTestCase(TestCase):
 
     @mock.patch("aea.cli.fetch._is_version_correct", return_value=False)
     @mock.patch("aea.cli.fetch.os.path.exists", return_value=True)
-    @mock.patch("aea.cli.fetch.copy_tree")
+    @mock.patch("shutil.copytree")
     def test_fetch_agent_locally_incorrect_version(self, *mocks):
         """Test for fetch_agent_locally method incorrect agent version."""
         ctx = ContextMock()
@@ -97,7 +97,7 @@ class FetchAgentLocallyTestCase(TestCase):
     @mock.patch("aea.cli.fetch._is_version_correct", return_value=True)
     @mock.patch("aea.cli.fetch.add_item")
     @mock.patch("aea.cli.fetch.os.path.exists", return_value=False)
-    @mock.patch("aea.cli.fetch.copy_tree")
+    @mock.patch("shutil.copytree")
     def test_fetch_agent_locally_with_deps_positive(self, *mocks):
         """Test for fetch_agent_locally method with deps positive result."""
         public_id = PublicIdMock.from_str("author/name:0.1.0")
@@ -112,7 +112,7 @@ class FetchAgentLocallyTestCase(TestCase):
 
     @mock.patch("aea.cli.fetch._is_version_correct", return_value=True)
     @mock.patch("aea.cli.fetch.os.path.exists", return_value=False)
-    @mock.patch("aea.cli.fetch.copy_tree")
+    @mock.patch("shutil.copytree")
     @mock.patch("aea.cli.fetch.add_item", _raise_click_exception)
     def test_fetch_agent_locally_with_deps_fail(self, *mocks):
         """Test for fetch_agent_locally method with deps ClickException catch."""


### PR DESCRIPTION
## Proposed changes

use shutil.copytree isntead of outdated distutils.dir_util

## Fixes

https://github.com/valory-xyz/open-aea/issues/553

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...


DELETE INCLUSIVE THIS AND BELOW FOR STANDARD PR
------

## Release summary

Version number: [e.g. 1.0.1]

## Release details

Describe in short the main changes with the new release.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [ ] Lint and unit tests pass locally and in CI
- [ ] I have checked the fingerprint hashes are correct by running (`aea packages lock --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

## Further comments

Write here any other comment about the release, if any.
