### PR TITLE
fix: remove `.hypothesis` before running generators [no ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,18 +27,22 @@ clean-pyc:
 	find . -name '.DS_Store' -exec rm -fr {} +
 
 .PHONY: clean-test
-clean-test:
+clean-test: clean-cache
 	rm -fr .tox/
 	rm -f .coverage
 	find . -name ".coverage*" -not -name ".coveragerc" -exec rm -fr "{}" \;
 	rm -fr coverage.xml
 	rm -fr htmlcov/
-	rm -fr .hypothesis
-	rm -fr .pytest_cache
-	rm -fr .mypy_cache/
-	rm -fr .hypothesis/
 	find . -name 'log.txt' -exec rm -fr {} +
 	find . -name 'log.*.txt' -exec rm -fr {} +
+
+# removes various cache files
+.PHONY: clean-cache
+clean-cache:
+	rm -fr .hypothesis/
+	rm -fr .pytest_cache
+	rm -fr .mypy_cache/
+
 
 .PHONY: package-checks
 package_checks:
@@ -159,7 +163,7 @@ security:
 # generate docs for updated packages
 # update copyright headers
 .PHONY: generators
-generators:
+generators: clean-cache
 	rm -rf packages/fetchai/connections/stub/input_file
 	tox -e fix-copyright
 	tox -e lock-packages


### PR DESCRIPTION
## Fixes

This PR makes sure `.hypothesis` and other cached files are removed before running generators. 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...