### PR TITLE
Add support for syncing hashes from github releases

### DIFF
--- a/aea/cli/packages.py
+++ b/aea/cli/packages.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022 Valory AG
+#   Copyright 2022-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/aea/cli/utils/click_utils.py
+++ b/aea/cli/utils/click_utils.py
@@ -47,6 +47,7 @@ from aea.configurations.constants import (
 )
 from aea.configurations.data_types import PackageType, PublicId
 from aea.helpers.io import open_file
+from aea.package_manager.base import PACKAGE_SOURCE_RE
 
 
 class ConnectionsOption(click.Option):
@@ -222,6 +223,25 @@ class AgentDirectory(click.Path):
             )
         finally:
             os.chdir(cwd)
+
+
+class PackagesSource(click.ParamType):
+    """Click paramater for package sources."""
+
+    def __init__(self) -> None:
+        """Initialize the package source parameter."""
+
+    def get_metavar(self, param: Any) -> str:
+        """Return the metavar default for this param if it provides one."""
+        return "SOURCE"  # pragma: no cover
+
+    def convert(self, value: str, param: Any, ctx: click.Context) -> str:
+        """Convert the value."""
+        if PACKAGE_SOURCE_RE.match(value) is None:
+            raise click.ClickException(
+                f"Bad value provided for package source `{value}`"
+            )
+        return value
 
 
 def registry_flag(

--- a/aea/package_manager/base.py
+++ b/aea/package_manager/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022 Valory AG
+#   Copyright 2022-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/aea/package_manager/base.py
+++ b/aea/package_manager/base.py
@@ -475,3 +475,7 @@ class PackageNotValid(Exception):
 
 class PackageFileNotValid(Exception):
     """Package file not valid."""
+
+
+class PackagesSourceNotValid(Exception):
+    """Packages source not valid."""

--- a/aea/package_manager/base.py
+++ b/aea/package_manager/base.py
@@ -22,6 +22,7 @@
 
 import json
 import logging
+import re
 import shutil
 from abc import ABC, abstractmethod
 from collections import OrderedDict
@@ -49,6 +50,7 @@ except (ImportError, ModuleNotFoundError):  # pragma: nocover  # cause obvious
     IS_IPFS_PLUGIN_INSTALLED = False
 
 PACKAGES_FILE = "packages.json"
+PACKAGE_SOURCE_RE = re.compile(r"([a-z-_0-9]+\/[a-z-_0-9]+)((:)([a-z\.0-9_-]+))?")
 
 PackageIdToHashMapping = OrderedDictType[PackageId, str]
 ConfigLoaderCallableType = Callable[[PackageType, Path], PackageConfiguration]

--- a/aea/package_manager/v1.py
+++ b/aea/package_manager/v1.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022 Valory AG
+#   Copyright 2022-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/aea/package_manager/v1.py
+++ b/aea/package_manager/v1.py
@@ -177,7 +177,7 @@ class PackageManagerV1(BasePackageManager):
             package_manager = self.from_json(packages=packages)
 
             for package_id in _updated_third_party_packages:
-                latest_hash = package_manager.get_package_hash(package_id=package_id)
+                latest_hash = package_manager.dev_packages.get(package_id)
                 if latest_hash is None:
                     continue
 

--- a/docs/api/package_manager/base.md
+++ b/docs/api/package_manager/base.md
@@ -338,3 +338,13 @@ class PackageFileNotValid(Exception)
 
 Package file not valid.
 
+<a id="aea.package_manager.base.PackagesSourceNotValid"></a>
+
+## PackagesSourceNotValid Objects
+
+```python
+class PackagesSourceNotValid(Exception)
+```
+
+Packages source not valid.
+

--- a/docs/api/package_manager/v1.md
+++ b/docs/api/package_manager/v1.md
@@ -111,7 +111,8 @@ Add package.
 def sync(dev: bool = False,
          third_party: bool = True,
          update_packages: bool = False,
-         update_hashes: bool = False) -> "PackageManagerV1"
+         update_hashes: bool = False,
+         sources: Optional[List[str]] = None) -> "PackageManagerV1"
 ```
 
 Sync local packages to the remote registry.
@@ -146,6 +147,22 @@ def json() -> OrderedDictType
 ```
 
 Json representation
+
+<a id="aea.package_manager.v1.PackageManagerV1.from_json"></a>
+
+#### from`_`json
+
+```python
+@classmethod
+def from_json(
+    cls,
+    packages: Dict[str, Dict[str, str]],
+    packages_dir: Optional[Path] = None,
+    config_loader: ConfigLoaderCallableType = load_configuration
+) -> "PackageManagerV1"
+```
+
+Initialize from json object
 
 <a id="aea.package_manager.v1.PackageManagerV1.from_dir"></a>
 

--- a/tests/test_package_manager/test_v1.py
+++ b/tests/test_package_manager/test_v1.py
@@ -246,7 +246,7 @@ class TestPackageManagerV1SourceSync(TestPackageManagerV1):
         """Test source sync."""
 
         latest_packages = copy.deepcopy(self.dummy_packages)
-        latest_packages["third_party"][
+        latest_packages["dev"][
             self.dummy_third_party_package.to_uri_path
         ] = self.dummy_third_party_package_latest
 


### PR DESCRIPTION
## Proposed changes

This PR adds support for syncing the third party hashes from the github releases when running package sync

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...