### PR TITLE
[DONOTMERGE] referenced relaxed ledger

### DIFF
--- a/plugins/aea-ledger-ethereum-hwi/setup.py
+++ b/plugins/aea-ledger-ethereum-hwi/setup.py
@@ -43,7 +43,7 @@ setup(
         "ipfshttpclient==0.8.0a2",
         "eth-account==0.5.6",
         "open-aea-ledger-ethereum~=1.31.0",
-        "apduboy>=0.5.0",
+        "apduboy @ https://github.com/8ball030/apduboy.git",
         "protobuf>=3.20,<4",
     ],
     tests_require=["pytest"],

--- a/plugins/aea-ledger-ethereum-hwi/setup.py
+++ b/plugins/aea-ledger-ethereum-hwi/setup.py
@@ -43,7 +43,7 @@ setup(
         "ipfshttpclient==0.8.0a2",
         "eth-account==0.5.6",
         "open-aea-ledger-ethereum~=1.31.0",
-        "apduboy @ https://github.com/8ball030/apduboy.git",
+        "apduboy @ git+ssh://git@github.com/8ball030/apduboy",
         "protobuf>=3.20,<4",
     ],
     tests_require=["pytest"],


### PR DESCRIPTION
## Proposed 
This references a dependency in an upstream repo which made it impossible to resolve dependencies.
Prior fix

![image](https://user-images.githubusercontent.com/35799987/227570896-a0c5aa27-bc40-4842-b1c3-8b68347b31a6.png)

Post fix/ referening my upstream.

![image](https://user-images.githubusercontent.com/35799987/227572847-0314be0b-dbb3-40a6-9366-2cab1566364f.png)


Referencing fix;

The upstream is;
https://github.com/LedgerHQ/apduboy/pull/3


Note, with all of these changes we can now do;


![image](https://user-images.githubusercontent.com/35799987/227574259-1caea7e5-10f5-48ff-9358-b3a5769f5e39.png)
