### PR TITLE
fix: attach plugin loggers to correct namespace

### DIFF
--- a/plugins/aea-ledger-cosmos/aea_ledger_cosmos/cosmos.py
+++ b/plugins/aea-ledger-cosmos/aea_ledger_cosmos/cosmos.py
@@ -100,7 +100,7 @@ def lazy_load():  # Python caches all imported modules
     return locals()
 
 
-_default_logger = logging.getLogger('aea.ledger_apis.cosmos')
+_default_logger = logging.getLogger("aea.ledger_apis.cosmos")
 
 _COSMOS = "cosmos"
 TESTNET_NAME = "testnet"

--- a/plugins/aea-ledger-cosmos/aea_ledger_cosmos/cosmos.py
+++ b/plugins/aea-ledger-cosmos/aea_ledger_cosmos/cosmos.py
@@ -100,7 +100,7 @@ def lazy_load():  # Python caches all imported modules
     return locals()
 
 
-_default_logger = logging.getLogger(__name__)
+_default_logger = logging.getLogger('aea.ledger_apis.cosmos')
 
 _COSMOS = "cosmos"
 TESTNET_NAME = "testnet"

--- a/plugins/aea-ledger-ethereum-flashbots/aea_ledger_ethereum_flashbots/ethereum_flashbots.py
+++ b/plugins/aea-ledger-ethereum-flashbots/aea_ledger_ethereum_flashbots/ethereum_flashbots.py
@@ -36,7 +36,7 @@ from aea.common import JSONLike
 from aea.helpers.base import try_decorator
 
 
-_default_logger = logging.getLogger('aea.ledger_apis.ethereum_flashbots')
+_default_logger = logging.getLogger("aea.ledger_apis.ethereum_flashbots")
 
 _ETHEREUM_FLASHBOTS = "ethereum_flashbots"
 

--- a/plugins/aea-ledger-ethereum-flashbots/aea_ledger_ethereum_flashbots/ethereum_flashbots.py
+++ b/plugins/aea-ledger-ethereum-flashbots/aea_ledger_ethereum_flashbots/ethereum_flashbots.py
@@ -36,7 +36,7 @@ from aea.common import JSONLike
 from aea.helpers.base import try_decorator
 
 
-_default_logger = logging.getLogger(__name__)
+_default_logger = logging.getLogger('aea.ledger_apis.ethereum_flashbots')
 
 _ETHEREUM_FLASHBOTS = "ethereum_flashbots"
 
@@ -158,7 +158,7 @@ class EthereumFlashbotApi(EthereumApi):
             try:
                 receipts = response.receipts()
                 tx_hashes = [tx["hash"].hex() for tx in response.bundle]
-                logging.debug(
+                _default_logger.debug(
                     f"Bundle with replacement uuid {replacement_uuid} was mined in block {receipts[0]['blockNumber']}"
                     f"Tx hashes: {tx_hashes}"
                 )
@@ -168,13 +168,13 @@ class EthereumFlashbotApi(EthereumApi):
                 stats = self.flashbots.get_bundle_stats_v2(
                     self.api.toHex(response.bundle_hash()), target_block
                 )
-                logging.debug(
+                _default_logger.info(
                     f"Bundle with replacement uuid {replacement_uuid} not found in block {target_block}. "
                     f"bundle stats: {stats}"
                 )
                 # essentially a no-op but it shows that the function works
                 cancel_res = self.flashbots.cancel_bundles(replacement_uuid)
-                logging.debug(
+                _default_logger.debug(
                     f"Response from canceling bundle with replacement uuid {replacement_uuid}: {cancel_res}"
                 )
         return None

--- a/plugins/aea-ledger-ethereum-hwi/aea_ledger_ethereum_hwi/hwi.py
+++ b/plugins/aea-ledger-ethereum-hwi/aea_ledger_ethereum_hwi/hwi.py
@@ -41,7 +41,7 @@ from aea.common import JSONLike
 from aea.crypto.base import Crypto
 
 
-_default_logger = logging.getLogger(__name__)
+_default_logger = logging.getLogger('aea.ledger_apis.ethereum_hwi')
 
 SignedTransactionTranslator = BaseSignedTransactionTranslator
 AttributeDictTranslator = BaseAttributeDictTranslator

--- a/plugins/aea-ledger-ethereum-hwi/aea_ledger_ethereum_hwi/hwi.py
+++ b/plugins/aea-ledger-ethereum-hwi/aea_ledger_ethereum_hwi/hwi.py
@@ -41,7 +41,7 @@ from aea.common import JSONLike
 from aea.crypto.base import Crypto
 
 
-_default_logger = logging.getLogger('aea.ledger_apis.ethereum_hwi')
+_default_logger = logging.getLogger("aea.ledger_apis.ethereum_hwi")
 
 SignedTransactionTranslator = BaseSignedTransactionTranslator
 AttributeDictTranslator = BaseAttributeDictTranslator

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -59,7 +59,7 @@ from aea.helpers.base import try_decorator
 from aea.helpers.io import open_file
 
 
-_default_logger = logging.getLogger(__name__)
+_default_logger = logging.getLogger('aea.ledger_apis.ethereum')
 
 _ETHEREUM = "ethereum"
 TESTNET_NAME = "ganache"

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -59,7 +59,7 @@ from aea.helpers.base import try_decorator
 from aea.helpers.io import open_file
 
 
-_default_logger = logging.getLogger('aea.ledger_apis.ethereum')
+_default_logger = logging.getLogger("aea.ledger_apis.ethereum")
 
 _ETHEREUM = "ethereum"
 TESTNET_NAME = "ganache"

--- a/plugins/aea-ledger-solana/aea_ledger_solana/utils.py
+++ b/plugins/aea-ledger-solana/aea_ledger_solana/utils.py
@@ -23,7 +23,7 @@ import zlib
 from typing import Any
 
 
-default_logger = logging.getLogger(__name__)
+default_logger = logging.getLogger('aea.ledger_apis.solana')
 
 
 def pako_inflate(data: Any) -> bytes:

--- a/plugins/aea-ledger-solana/aea_ledger_solana/utils.py
+++ b/plugins/aea-ledger-solana/aea_ledger_solana/utils.py
@@ -23,7 +23,7 @@ import zlib
 from typing import Any
 
 
-default_logger = logging.getLogger('aea.ledger_apis.solana')
+default_logger = logging.getLogger("aea.ledger_apis.solana")
 
 
 def pako_inflate(data: Any) -> bytes:


### PR DESCRIPTION
## Fixes

This PR attaches the plugin loggers to the correct namespace (aea).

Note:
Using `__name__` when initializing plugins might result in a different namespace then expected.
Logger configurations are [hierarchical](https://docs.python.org/3/howto/logging.html#advanced-logging-tutorial:~:text=Each%20instance%20has%20a%20name%2C%20and%20they%20are%20conceptually%20arranged%20in%20a%20namespace%20hierarchy).

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

