### PR TITLE
Release v1.39.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 # Release History - open AEA
 
 
+## 1.39.0 (2023-09-07)
+
+AEA:
+- Removes the rust installation layer from the user image
+
+
 ## 1.38.0 (2023-08-09)
 
 Framework:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-aea` are currently being suppo
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `1.38.x`   | :white_check_mark: |
-| `< 1.38.0` | :x:                |
+| `1.39.x`   | :white_check_mark: |
+| `< 1.39.0` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.38.0"
+__version__ = "1.39.0"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.38.0 "open-aea-cli-ipfs<2.0.0,>=1.38.0"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.39.0 "open-aea-cli-ipfs<2.0.0,>=1.39.0"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.38.0/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.39.0/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.38.0
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.39.0
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,6 +9,9 @@ Below we describe the additional manual steps required to upgrade between differ
 
 ### Upgrade guide
 
+## `v1.38.0` to `v1.39.0`
+
+- No backwards incompatible changes
 
 ## `v1.37.0` to `v1.38.0`
 

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall aea[all]==1.38.0
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.39.0
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-benchmark",
-    version="1.38.0",
+    version="1.39.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.38.0",
+    version="1.39.0",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.38.0",
+    version="1.39.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum-flashbots/setup.py
+++ b/plugins/aea-ledger-ethereum-flashbots/setup.py
@@ -25,7 +25,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum-flashbots",
-    version="1.38.0",
+    version="1.39.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package extending the default open-aea ethereum ledger plugin to add support for flashbots.",
@@ -41,7 +41,7 @@ setup(
     },
     python_requires=">=3.9,<4.0",
     install_requires=[
-        "open-aea-ledger-ethereum~=1.38.0",
+        "open-aea-ledger-ethereum~=1.39.0",
         "open-aea-flashbots==1.3.0",
     ],
     tests_require=["pytest"],

--- a/plugins/aea-ledger-ethereum-hwi/setup.py
+++ b/plugins/aea-ledger-ethereum-hwi/setup.py
@@ -25,7 +25,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum-hwi",
-    version="1.38.0",
+    version="1.39.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and support for hardware wallet interactions.",
@@ -42,7 +42,7 @@ setup(
         "open-aea-web3==6.0.1",
         "ipfshttpclient==0.8.0a2",
         "eth-account>=0.8.0,<0.9.0",
-        "open-aea-ledger-ethereum~=1.38.0",
+        "open-aea-ledger-ethereum~=1.39.0",
         "ledgerwallet==0.1.3",
         "protobuf==3.19.5",
         "construct<=2.10.61",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.38.0",
+    version="1.39.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.38.0",
+    version="1.39.0",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",
@@ -44,7 +44,7 @@ setup(
             "test_tools/data/*",
         ]
     },
-    install_requires=["open-aea-ledger-cosmos~=1.38.0"],
+    install_requires=["open-aea-ledger-cosmos~=1.39.0"],
     tests_require=["pytest"],
     entry_points={
         "aea.cryptos": ["fetchai = aea_ledger_fetchai:FetchAICrypto"],

--- a/plugins/aea-ledger-solana/setup.py
+++ b/plugins/aea-ledger-solana/setup.py
@@ -25,7 +25,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-solana",
-    version="1.38.0",
+    version="1.39.0",
     author="dassy23",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of solana.",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.38.0 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.39.0 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.38.0 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.39.0 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.38.0"
+      template: "1.39.0"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.38.0"
+          template: "1.39.0"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -3,14 +3,11 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install sudo git curl -y
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > ./rustup.sh
-RUN sh ./rustup.sh -y
-
 RUN adduser --disabled-password --gecos '' ubuntu
 RUN adduser ubuntu sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-RUN apt install -y python3.10 python3.10-dev python3-pip
+RUN apt install -y python3.10 python3.10-dev python3-pip libffi-dev
 RUN pip3 install --upgrade pip
 RUN pip3 install pipenv
 
@@ -35,6 +32,5 @@ COPY user-image/openssl.cnf /etc/ssl
 RUN echo 'PATH="$(python3.10 -m site --user-base)/bin:${PATH}"' >> ~/.bashrc
 RUN echo "alias pip=pip3" >> ~/.bashrc
 RUN echo "alias python=python3.10" >> ~/.bashrc
-
 
 ENTRYPOINT [ "/bin/bash"]

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.38.0
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.39.0
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.39.0

## Release details

AEA:
- Removes the rust installation layer from the user image

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [ ] Lint and unit tests pass locally and in CI
- [ ] I have checked the fingerprint hashes are correct by running (`aea packages lock --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

## Further comments

Write here any other comment about the release, if any.
