### PR TITLE
Release v1.43.0.post2

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -381,3 +381,4 @@ pyyaml
 1.39.0.post1
 1.41.0.post1
 1.43.0.post1
+1.43.0.post2

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,14 @@
 # Release History - open AEA
 
+## 1.43.0.post2 (2023-12-26)
+
+AEA:
+- Fixes the default environment variable parsing for the base types
+
 ## 1.43.0.post1 (2023-12-19)
 
 AEA:
-- Fixes the default environment variable parsing
+- Fixes the default environment variable parsing for the list types
 
 ## 1.43.0 (2023-12-14)
 

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "1.43.0.post1"
+__version__ = "1.43.0.post2"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/aea/helpers/env_vars.py
+++ b/aea/helpers/env_vars.py
@@ -91,11 +91,12 @@ def replace_with_env_var(
 
     if var_name in env_variables:
         var_value = env_variables[var_name]
-    elif type_str == "list" and var_name == default_var_name:
+    elif type_str == "list":
         var_value = parse_list(
             var_prefix=var_name,
             env_variables=env_variables,
         )
+        var_value = (default or var_value) if var_value == "[]" else var_value
     elif default is not None:
         var_value = default
     elif default_value is not NotSet:
@@ -107,7 +108,6 @@ def replace_with_env_var(
 
     if type_str is not None:
         var_value = convert_value_str_to_type(var_value, type_str)
-
     return var_value
 
 

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.43.0.post1 "open-aea-cli-ipfs<2.0.0,>=1.43.0.post1"
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.43.0.post2 "open-aea-cli-ipfs<2.0.0,>=1.43.0.post2"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v1.43.0.post1/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v1.43.0.post2/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:1.43.0.post1
+DOCKER_IMAGE_TAG=valory/open-aea-develop:1.43.0.post2
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,7 +9,15 @@ Below we describe the additional manual steps required to upgrade between differ
 
 ### Upgrade guide
 
-## `v1.42.0` to `v1.43.0.post1`
+## `v1.43.0.post1` to `v1.43.0.post2`
+
+- No backwards incompatible changes
+
+## `v1.43.0` to `v1.43.0.post1`
+
+- No backwards incompatible changes
+
+## `v1.42.0` to `v1.43.0`
 
 - No backwards incompatible changes
 

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==1.43.0.post1
+RUN pip install --upgrade --force-reinstall open-aea[all]==1.43.0.post2
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-benchmark",
-    version="1.43.0.post1",
+    version="1.43.0.post2",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="open-aea-cli-ipfs",
-    version="1.43.0.post1",
+    version="1.43.0.post2",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="1.43.0.post1",
+    version="1.43.0.post2",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum-flashbots/setup.py
+++ b/plugins/aea-ledger-ethereum-flashbots/setup.py
@@ -25,7 +25,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum-flashbots",
-    version="1.43.0.post1",
+    version="1.43.0.post2",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package extending the default open-aea ethereum ledger plugin to add support for flashbots.",
@@ -41,7 +41,7 @@ setup(
     },
     python_requires=">=3.9,<4.0",
     install_requires=[
-        "open-aea-ledger-ethereum~=1.43.0.post1",
+        "open-aea-ledger-ethereum~=1.43.0.post2",
         "open-aea-flashbots==1.4.0",
     ],
     tests_require=["pytest"],

--- a/plugins/aea-ledger-ethereum-hwi/setup.py
+++ b/plugins/aea-ledger-ethereum-hwi/setup.py
@@ -25,7 +25,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum-hwi",
-    version="1.43.0.post1",
+    version="1.43.0.post2",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and support for hardware wallet interactions.",
@@ -42,7 +42,7 @@ setup(
         "web3>=6.0.0,<7",
         "ipfshttpclient==0.8.0a2",
         "eth-account>=0.8.0,<0.9.0",
-        "open-aea-ledger-ethereum~=1.43.0.post1",
+        "open-aea-ledger-ethereum~=1.43.0.post2",
         "ledgerwallet==0.1.3",
         "protobuf<4.25.0,>=4.21.6",
         "construct<=2.10.61",

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -26,7 +26,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="1.43.0.post1",
+    version="1.43.0.post2",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -31,7 +31,7 @@ plugin_dir = os.path.abspath(os.path.join(here, ".."))
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="1.43.0.post1",
+    version="1.43.0.post2",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",
@@ -44,7 +44,7 @@ setup(
             "test_tools/data/*",
         ]
     },
-    install_requires=["open-aea-ledger-cosmos~=1.43.0.post1"],
+    install_requires=["open-aea-ledger-cosmos~=1.43.0.post2"],
     tests_require=["pytest"],
     entry_points={
         "aea.cryptos": ["fetchai = aea_ledger_fetchai:FetchAICrypto"],

--- a/plugins/aea-ledger-solana/setup.py
+++ b/plugins/aea-ledger-solana/setup.py
@@ -25,7 +25,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="open-aea-ledger-solana",
-    version="1.43.0.post1",
+    version="1.43.0.post2",
     author="dassy23",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of solana.",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==1.43.0.post1 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==1.43.0.post2 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==1.43.0.post1 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==1.43.0.post2 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "1.43.0.post1"
+      template: "1.43.0.post2"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "1.43.0.post1"
+          template: "1.43.0.post2"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/tests/test_helpers/test_env_vars.py
+++ b/tests/test_helpers/test_env_vars.py
@@ -226,6 +226,37 @@ def test_match_export_parse_consistency(export_data, template) -> None:
     assert parsed_data == export_data
 
 
+@pytest.mark.parametrize(
+    ("template", "parsed"),
+    argvalues=[
+        (
+            {"value": "${str:john}"},
+            {"value": "john"},
+        ),
+        (
+            {"value": "${int:3}"},
+            {"value": 3},
+        ),
+        (
+            {"value": "${bool:false}"},
+            {"value": False},
+        ),
+        (
+            {"value": '${list:["foo","bar"]}'},
+            {"value": ["foo", "bar"]},
+        ),
+        (
+            {"value": '${dict:{"foo":"bar"}}'},
+            {"value": {"foo": "bar"}},
+        ),
+    ],
+)
+def test_parse_defaults(template, parsed) -> None:
+    """Test default value parsing."""
+    parsed_data = apply_env_variables(template, env_variables={})
+    assert parsed_data == parsed
+
+
 def test_apply_env_variables_on_agent_config():
     """Test apply_env_variables_on_agent_config function."""
     result = apply_env_variables_on_agent_config(

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG C.UTF-8
 RUN apt update && apt install -y python3.11-dev python3-pip -y && apt autoremove && apt autoclean
 
 RUN pip3 install --upgrade pip
-RUN pip3 install "open-aea[all]==1.43.0.post1" open-aea-cli-ipfs==1.43.0.post1
+RUN pip3 install "open-aea[all]==1.43.0.post2" open-aea-cli-ipfs==1.43.0.post2
 
 COPY user-image/openssl.cnf /etc/ssl
 

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:1.43.0.post1
+DOCKER_IMAGE_TAG=valory/open-aea-user:1.43.0.post2
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: v1.43.0.post2

## Release details

AEA:
- Fixes the default environment variable parsing for the base types

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [ ] Lint and unit tests pass locally and in CI
- [ ] I have checked the fingerprint hashes are correct by running (`aea packages lock --check`)
- [ ] I have regenerated the latest API docs
- [ ] I built the documentation and updated it with the latest changes
- [ ] I have added an item in `HISTORY.md` for this release
- [ ] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest`  
      (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) 
      and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.
