### PR TITLE
Permit earlier click version

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,5 @@ filterwarnings =
     ignore:Call to deprecated create function EnumValueDescriptor().
     ignore:Call to deprecated create function EnumDescriptor().
     ignore:The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
-    ignore:'resultcallback' has been renamed to 'result_callback'. The old name will be removed in Click 8.1.
     ignore:There is no current event loop
     ignore::DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,5 +20,6 @@ filterwarnings =
     ignore:Call to deprecated create function EnumValueDescriptor().
     ignore:Call to deprecated create function EnumDescriptor().
     ignore:The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
+    ignore:'resultcallback' has been renamed to 'result_callback'. The old name will be removed in Click 8.1.
     ignore:There is no current event loop
     ignore::DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def get_all_extras() -> Dict:
     cli_deps = [
-        "click>=8.1.0,<9",
+        "click>=8.0.2,<9",
         "pyyaml>=6.0.1,<9",
         "packaging>=23.1,<24.0",
         "pytest>=7.0.0,<7.3.0",

--- a/tests/test_test_tools/test_click_testing.py
+++ b/tests/test_test_tools/test_click_testing.py
@@ -105,7 +105,7 @@ def test_click_version():
     When this tests fails you need to ensure that the current versions implementation
     of the click.testing.CliRunner remains compatible with our monkey-patched version
     """
-    assert click.__version__ == "8.1.7", message
+    assert click.__version__ == "8.0.2", message
 
 
 @pytest.mark.parametrize("mix_stderr", [True, False])


### PR DESCRIPTION
## Proposed changes

Downgrade minimum `click` version back to `1.51.0` release version (i.e. undoing min version bump from https://github.com/valory-xyz/open-aea/pull/736)

## Fixes

https://github.com/valory-xyz/open-aea/pull/736 will introduce dependency conflicts in upstream projects that depend on both https://github.com/valory-xyz/open-aea and https://github.com/valory-xyz/open-autonomy (like https://github.com/valory-xyz/mech-client) in the next release of this repo (1.52.0). This change fixes that.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Release summary

This should be included in release 1.52.0 (for which release notes were added in https://github.com/valory-xyz/open-aea/pull/736/files)
