### PR TITLE
Relax python-dotenv dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ base_deps = [
     "pymultihash==0.8.2",
     "pyyaml>=6.0.1,<7",
     "requests>=2.28.1,<3",
-    "python-dotenv>=0.14.0,<0.22.0",
+    "python-dotenv>=0.14.0,<1.0.1",
     "ecdsa>=0.15,<0.17.0",
     "morphys>=1.0",
     "py-multibase>=1.0.0",


### PR DESCRIPTION
## Proposed changes

Relax `python-dotenv` dependency. The only use of the package in open-aea is here https://github.com/valory-xyz/open-aea/blob/main/aea/helpers/base.py#L144. This is compatible with the newest release of `python-dotenv`.

## Types of changes

No functional changes. Dependency change only.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
