### PR TITLE
Fix (CLI): Avoid validation failures with `--help`

### DIFF
--- a/aea/cli/utils/decorators.py
+++ b/aea/cli/utils/decorators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021-2023 Valory AG
+#   Copyright 2021-2024 Valory AG
 #   Copyright 2018-2020 Fetch.AI Limited
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@
 
 import os
 import shutil
+import sys
 from functools import update_wrapper
 from pathlib import Path
 from typing import Any, Callable, Dict, Tuple, Union, cast
@@ -178,12 +179,13 @@ def check_aea_project(
 
     def wrapper(*args: Any, **kwargs: Any) -> Callable:
         to_local_registry = cast(bool, kwargs.get("to_local_registry"))
-        _check_aea_project(
-            args,
-            check_aea_version=check_aea_version,
-            check_finger_prints=check_finger_prints,
-            to_local_registry=to_local_registry,
-        )
+        if not ("--help" in sys.argv or "-h" in sys.argv):
+            _check_aea_project(
+                args,
+                check_aea_version=check_aea_version,
+                check_finger_prints=check_finger_prints,
+                to_local_registry=to_local_registry,
+            )
         return f(*args, **kwargs)
 
     return update_wrapper(wrapper, f)


### PR DESCRIPTION
## Proposed changes

Not do validation checks when passing `--help` or `-h` in CLI

## Fixes

Closes https://github.com/valory-xyz/open-autonomy/issues/1684

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
