### PR TITLE
fix: add from address in request

### DIFF
--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -1003,6 +1003,7 @@ class EthereumApi(LedgerApi, EthereumHelper):
         if nonce is None:
             return transaction
         transaction = {
+            "from": sender_address,
             "nonce": nonce,
             "chainId": chain_id,
             "to": destination_address,

--- a/plugins/aea-ledger-ethereum/tests/test_ethereum.py
+++ b/plugins/aea-ledger-ethereum/tests/test_ethereum.py
@@ -422,7 +422,7 @@ def test_ethereum_api_get_transfer_transaction_2(*args):
         "max_fee_per_gas": 10,
     }
     with patch.object(ethereum_api.api.eth, "estimate_gas", return_value=1):
-        assert len(ethereum_api.get_transfer_transaction(**args)) == 8
+        assert len(ethereum_api.get_transfer_transaction(**args)) == 9
 
 
 @patch.object(EthereumApi, "_try_get_transaction_count", return_value=1)
@@ -441,7 +441,7 @@ def test_ethereum_api_get_transfer_transaction_3(*args):
         "max_fee_per_gas": 10,
     }
     with patch.object(ethereum_api.api.eth, "_max_priority_fee", return_value=1):
-        assert len(ethereum_api.get_transfer_transaction(**args)) == 8
+        assert len(ethereum_api.get_transfer_transaction(**args)) == 9
 
 
 def test_ethereum_api_get_deploy_transaction(ethereum_testnet_config):


### PR DESCRIPTION
## Proposed Changes
This update addresses an issue in aea-ledger-ethereum where the "from" parameter was missing in requests for gas estimation. By default, the zero address is assumed as the sender, but on chains like Mode, this default address lacks sufficient funds compared to other chains, causing gas estimation to fail.

## Fixes
Include the "from" parameter in the transaction when making an RPC call for eth_estimateGas

