### PR TITLE
fix: rewards issue

### DIFF
--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -180,17 +180,14 @@ def estimate_priority_fee(
         fee_history = web3_object.eth.fee_history(
             fee_history_blocks, block_number, [fee_history_percentile]  # type: ignore
         )
-        
         # This is going to break if more percentiles are introduced in the future,
         # i.e., `fee_history_percentile` param becomes a `List[int]`.
         rewards = sorted(
             [reward[0] for reward in fee_history.get("reward", []) if reward[0] > 0]
         )
-
         # we need atleast 2 rewards to proceed further
         if len(rewards) >= 2:
             break
-        
         # Increment percentile for next attempt
         fee_history_percentile = min(100, fee_history_percentile + PERCENTILE_INCREASE)
 

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -84,6 +84,8 @@ SPEED_FAST = "fast"  # safeLow, standard, fast
 POLYGON_GAS_ENDPOINT = "https://gasstation-mainnet.matic.network/v2"
 MAX_GAS_FAST = 1500
 RPC_CALL_MAX_WORKERS = 1
+N_RETRIES = 3
+PERCENTILE_INCREASE = 5
 
 # How many blocks to consider for priority fee estimation
 FEE_HISTORY_BLOCKS = 10
@@ -174,16 +176,26 @@ def estimate_priority_fee(
     if default_priority_fee is not None:
         return default_priority_fee
 
-    fee_history = web3_object.eth.fee_history(
-        fee_history_blocks, block_number, [fee_history_percentile]  # type: ignore
-    )
+    for _ in range(N_RETRIES):
+        fee_history = web3_object.eth.fee_history(
+            fee_history_blocks, block_number, [fee_history_percentile]  # type: ignore
+        )
+        
+        # This is going to break if more percentiles are introduced in the future,
+        # i.e., `fee_history_percentile` param becomes a `List[int]`.
+        rewards = sorted(
+            [reward[0] for reward in fee_history.get("reward", []) if reward[0] > 0]
+        )
 
-    # This is going to break if more percentiles are introduced in the future,
-    # i.e., `fee_history_percentile` param becomes a `List[int]`.
-    rewards = sorted(
-        [reward[0] for reward in fee_history.get("reward", []) if reward[0] > 0]
-    )
-    if len(rewards) == 0:
+        # we need atleast 2 rewards to proceed further
+        if len(rewards) >= 2:
+            break
+        
+        # Increment percentile for next attempt
+        fee_history_percentile = min(100, fee_history_percentile + PERCENTILE_INCREASE)
+
+    # Return None if fewer than 2 rewards after retries
+    if len(rewards) < 2:
         return None
 
     # Calculate percentage increases from between ordered list of fees

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -190,7 +190,7 @@ def estimate_priority_fee(
     percentage_increases = [
         ((j - i) / i) * 100 if i != 0 else 0 for i, j in zip(rewards[:-1], rewards[1:])
     ]
-    highest_increase = max(*percentage_increases)
+    highest_increase = max(percentage_increases)
     highest_increase_index = percentage_increases.index(highest_increase)
 
     values = rewards.copy()


### PR DESCRIPTION
## Proposed changes

This update addresses an edge case in transaction fee history calculations. The issue arises when there are only two rewards in the fee history. In such cases, calculating percentage increases would produce a single-element list, causing an error during unpacking. 

Additionally, we’ve identified a potential edge case: if only one reward is present, calculating percentage increases would yield an empty list, leading to a failure.

## Fixes

- Resolved unpacking issue by removing the unpack operator.
- To handle the single-reward scenario, we’ve introduced a fallback mechanism:
   - Incrementally adjust the fee history percentile up to a maximum of 3 retries to obtain at least two rewards.
