### PR TITLE
Fix docs dependency `mkdocs-mermaid-plugin`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -280,7 +280,7 @@ skipsdist = True
 skip_install = True
 deps =
     tomte[docs]==0.2.13
-commands = pip3 install git+https://github.com/pugong/mkdocs-mermaid-plugin.git#egg=mkdocs-mermaid-plugin
+commands = pip3 install git+https://github.com/pugong/mkdocs-mermaid-plugin.git@abf1439#egg=mkdocs-mermaid-plugin
            mkdocs build --clean
 
 [testenv:docs-serve]
@@ -288,7 +288,7 @@ skipsdist = True
 skip_install = True
 deps =
     tomte[docs]==0.2.13
-commands = pip3 install git+https://github.com/pugong/mkdocs-mermaid-plugin.git#egg=mkdocs-mermaid-plugin
+commands = pip3 install git+https://github.com/pugong/mkdocs-mermaid-plugin.git@abf1439#egg=mkdocs-mermaid-plugin
            mkdocs build --clean
            python -c 'print("###### Starting local server. Press Control+C to stop server ######")'
            mkdocs serve -a localhost:8080


### PR DESCRIPTION
## Proposed changes

Hi, I tried to build the documentation of the project from source.

However, after I set up the development environment and I run the command `mkdocs serve`, I got:

```
INFO    -  Building documentation... 
ERROR   -  Config value: 'theme'. Error: Unrecognised theme name: 'material'. The available installed themes are: mkdocs, readthedocs 
ERROR   -  Config value: 'markdown_extensions'. Error: Failed loading extension "pymdownx.superfences". 
ERROR   -  Config value: 'plugins'. Error: The "markdownmermaid" plugin is not installed 
```

Therefore, I first added `tomte` with extras `docs` (as in `tox.ini`): 4c2a3ed5f684be727e34b111f20fe81b0dfaed22

Then, after rerunning `mkdocs serve`, I got:

```
ERROR   -  Config value 'plugins': The "markdownmermaid" plugin is not installed

Aborted with a configuration error!
```

So I added `mkdocs-mermaid-plugin` in `Pipfile`: 35c82502aa965d198190d92ad9354ce582178e37
I used the same command occurring in `tox.ini`, except that now it points to a specific commit, which is a more robust approach instead of pointing to the default branch, see [44edcc9](https://github.com/valory-xyz/open-aea/pull/776/commits/44edcc9f9b2310082b61cfb7d3ff0dbbb5e5e2ee)


## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

no