### PR TITLE
docs: fix reference to multiplexer image

### DIFF
--- a/docs/core-components-1.md
+++ b/docs/core-components-1.md
@@ -50,7 +50,7 @@ An AEA runs and manages `Connections` via a `Multiplexer`.
 
 ### Multiplexer
 
-<img src="../assets/multiplexer_.png" alt="Multiplexer of an AEA" class="center" style="display: block; margin-left: auto; margin-right: auto;width:50%;">
+<img src="../assets/multiplexer.svg" alt="Multiplexer of an AEA" class="center" style="display: block; margin-left: auto; margin-right: auto;width:50%;">
 
 The <a href="../api/multiplexer#multiplexer-objects">`Multiplexer`</a> is responsible for maintaining (potentially multiple) `Connections`.
 

--- a/docs/core-components-1.md
+++ b/docs/core-components-1.md
@@ -50,7 +50,7 @@ An AEA runs and manages `Connections` via a `Multiplexer`.
 
 ### Multiplexer
 
-<img src="../assets/multiplexer.png" alt="Multiplexer of an AEA" class="center" style="display: block; margin-left: auto; margin-right: auto;width:50%;">
+<img src="../assets/multiplexer_.png" alt="Multiplexer of an AEA" class="center" style="display: block; margin-left: auto; margin-right: auto;width:50%;">
 
 The <a href="../api/multiplexer#multiplexer-objects">`Multiplexer`</a> is responsible for maintaining (potentially multiple) `Connections`.
 


### PR DESCRIPTION
## Proposed changes

In the documentation page `core-components-1.md`, the multiplexer image pointed to path `../assets/multiplexer.png`, but this path does not exist. Instead, it should point to the file `../assets/multiplexer_.png`.

This commit fixes the reference to the image.


## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a