### PR TITLE
Make the public RPCs overridable via environment variables

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -527,6 +527,17 @@ jobs:
           tox -e packages-py${{ matrix.python_version }} -- -m 'not integration and not unstable and not profiling'
 
       - name: Plugin unit tests
+        env:
+          RPC_ETHEREUM: ${{ secrets.RPC_ETHEREUM || 'https://eth.drpc.org' }}
+          RPC_ARBITRUM: ${{ secrets.RPC_ARBITRUM || 'https://arbitrum.drpc.org' }}
+          RPC_ZKSYNC: ${{ secrets.RPC_ZKSYNC || 'https://mainnet.era.zksync.io' }}
+          RPC_BINANCE: ${{ secrets.RPC_BINANCE || 'https://binance.llamarpc.com' }}
+          RPC_GNOSIS: ${{ secrets.RPC_GNOSIS || 'https://gnosis.drpc.org' }}
+          RPC_OPTIMISM: ${{ secrets.RPC_OPTIMISM || 'https://optimism.drpc.org' }}
+          RPC_BASE: ${{ secrets.RPC_BASE || 'https://base.drpc.org' }}
+          RPC_MODE: ${{ secrets.RPC_MODE || 'https://mode.drpc.org' }}
+          RPC_POLYGON: ${{ secrets.RPC_POLYGON || 'https://polygon.drpc.org' }}
+          RPC_FRAXTAL: ${{ secrets.RPC_FRAXTAL || 'https://fraxtal.drpc.org' }}
         run: |
           tox -e plugins-py${{ matrix.python_version }} -- -m 'not integration and not unstable and not profiling'
 


### PR DESCRIPTION
## Proposed changes

Addresses the flakiness of the EIP-1559 test (introduced in #791) by allowing RPCs to be overridden via environment variables. This will minimize CI failures if the public RPCs get overridden with more reliable ones.

Further improves the work in #792.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a