### PR TITLE
ci: add all_checks_passed aggregate gate

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -660,3 +660,32 @@ jobs:
           go mod tidy
           go build ./...
           go vet ./...
+
+  all_checks_passed:
+    # Aggregate gate used by branch protection as the single required
+    # status check. Update `needs` when adding/removing mandatory jobs.
+    name: All checks passed
+    if: always()
+    needs:
+      - common_checks_1
+      - common_checks_2
+      - common_checks_3
+      - common_checks_4
+      - common_checks_5
+      - copyright_check
+      - scan
+      - dependencies_checks
+      - plugins_install_check
+      - protolint
+      - platform_checks
+      - golang_checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One or more required jobs failed or were cancelled."
+          exit 1
+      - name: Success
+        run: echo "All required jobs succeeded."


### PR DESCRIPTION
## Summary
- Adds an `all_checks_passed` meta job to `workflow.yml` that depends on every required workflow job (`common_checks_1..5`, `copyright_check`, `scan`, `dependencies_checks`, `plugins_install_check`, `protolint`, `platform_checks`, `golang_checks`).
- The job runs with `if: always()` and fails if any dependency reports `failure` or `cancelled`.
- Intended to become the single required status check in branch protection for `main`, so the protected-branch contexts list does not need updating whenever CI jobs are added or renamed.

## Follow-up (after merge)
- Update `main` branch protection with `required_status_checks: { strict: true, contexts: ["All checks passed"] }` once GitHub has observed the new check run.

## Test plan
- [x] Workflow parses successfully and all existing jobs still run.
- [x] The new `All checks passed` job appears in the check list on this PR.
- [x] The `All checks passed` job transitions to success only after all listed dependencies succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)