### PR TITLE
chore: release v2.2.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,18 @@
 # Release History - open AEA
 
+## 2.2.3 (2026-05-04)
+
+AEA:
+
+- Bumps the `GitPython` floor to `>=3.1.47,<4.0.0` to pull in the upstream fixes for `GHSA-rpm5-65cw-6hj4` (insecure non-multi options in clone / clone_from) and `GHSA-x2qx-6953-8485` (blind local-file-read via `git ls-remote`). #884
+
+Tooling:
+
+- Collapses the four out-of-band lint/test config files (`pytest.ini`, `setup.cfg`, `.pylintrc`, `.gitleaks.toml`) into `pyproject.toml` + `tox.ini` (Wave 2a). Pytest config moves to `[tool.pytest.ini_options]`; the only remaining `setup.cfg` content is a minimal `[isort]` block consumed by `aea generate-all-protocols` to format generated protocol code. `[mypy]` and per-module `[mypy-*]` overrides plus the `[darglint]` block live at the bottom of `tox.ini` (mypy/darglint don't read pyproject.toml); the `[testenv:mypy]` command passes `--config-file=tox.ini` so they're picked up. #885
+- Bumps `tomte` to `==0.7.0` (released). Every lint testenv now references `{envsitepackagesdir}/tomte/configs/<config>` for its config — pylint, mypy, isort, flake8, bandit, darglint, safety, gitleaks — instead of carrying a forked copy in this repo. The pylint testenv keeps OAEA-specific extras (`--ignored-modules=…`, `--ignore-patterns=…`) inline because they're project-specific. #885
+- Slims `pyproject.toml` to strict PEP 621 + `[tool.poetry]` + `[tool.pytest.ini_options]` + `[tool.isort]` (no `[tool.pylint.*]` / `[tool.flake8]` / `[tool.mypy]` blocks). #885
+- Updates the `gitleaks` GitHub Actions job to install tomte and run with `--config={envsitepackagesdir}/tomte/configs/gitleaks.toml`. The previous job ran against gitleaks default rules. `.gitleaksignore` regenerated via `tomte freeze-gitleaks` (66 historical fingerprints). #885
+
 ## 2.2.2 (2026-04-24)
 
 Plugins:

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.3 "open-aea-cli-ipfs<3.0.0,>=2.2.2"
+RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.3 "open-aea-cli-ipfs<3.0.0,>=2.2.3"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.2 "open-aea-cli-ipfs<3.0.0,>=2.2.2"
+RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.3 "open-aea-cli-ipfs<3.0.0,>=2.2.2"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v2.2.2/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v2.2.3/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:2.2.2
+DOCKER_IMAGE_TAG=valory/open-aea-develop:2.2.3
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,6 +9,29 @@ Below we describe the additional manual steps required to upgrade between differ
 
 ### Upgrade guide
 
+## `v2.2.2` to `v2.2.3`
+
+This is a non-breaking patch release. There are no API or runtime behaviour changes; the work below is a security bump and a repo-wide lint/test config consolidation that does not affect downstream consumers.
+
+### `aea` core — `GitPython` floor bumped to `>=3.1.47`
+
+`open-aea` now requires `GitPython>=3.1.47,<4.0.0` to pull in the upstream fixes for `GHSA-rpm5-65cw-6hj4` (insecure non-multi options accepted by `clone` / `clone_from`) and `GHSA-x2qx-6953-8485` (blind local-file-read via `git ls-remote`). Projects that pinned `GitPython<3.1.47` directly will need to widen the pin.
+
+### Tooling — lint/test config consolidation
+
+`pytest.ini`, `.pylintrc`, and the forked `.gitleaks.toml` were removed. The remaining lint configuration now comes from canonical configs shipped by `tomte==0.7.0` (`{envsitepackagesdir}/tomte/configs/`), with OAEA-specific overrides layered in `tox.ini`. `setup.cfg` is preserved as a minimal `[isort]` stub because `aea generate-all-protocols` invokes isort with `--settings-path=setup.cfg` against generated protocol code; that path is unchanged.
+
+This is internal cleanup. Downstream consumers who don't fork OAEA's tox/pyproject have nothing to do. Forks that:
+
+- pinned the previous `tomte[tox,tests]==0.6.5`: bump to `==0.7.0`. Tomte 0.7.0 ships canonical `pylintrc` / `mypy.ini` / `gitleaks.toml` / `flake8.cfg` / `darglint` / `safety.toml` / `isort.cfg` resources; reference them from your testenvs as `{envsitepackagesdir}/tomte/configs/<config>` rather than maintaining your own copies.
+- mirrored OAEA's `[tool.flake8]` / `[tool.pylint.*]` / `[tool.mypy]` blocks in `pyproject.toml`: those blocks no longer exist here. Move per-package mypy overrides next to the testenv that runs mypy (mypy doesn't auto-discover tox.ini, so pass `--config-file=tox.ini`). Move darglint settings to `[darglint]` in `tox.ini` (darglint doesn't read pyproject.toml either).
+
+### Concrete upgrade steps
+
+- `pip install --upgrade "open-aea[all]==2.2.3"` (and the same `2.2.3` pin for any `open-aea-*` plugin you use).
+- `aea --version` should report `2.2.3`.
+- If you pin `GitPython` directly, ensure your pin allows `>=3.1.47`.
+
 ## `v2.2.1` to `v2.2.2`
 
 This is a non-breaking patch release. The core framework is unchanged; the notes below concern the Ethereum and Solana ledger plugins.

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.2
+RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.3
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-ci-helpers/aea_ci_helpers/check_third_party_hashes.py
+++ b/plugins/aea-ci-helpers/aea_ci_helpers/check_third_party_hashes.py
@@ -26,7 +26,7 @@ version tag. This command verifies that alignment.
 
 Upstreams are passed as ``owner/repo@version`` and may be repeated. The
 ``version`` segment may optionally include a leading ``v`` — both
-``@2.2.2`` and ``@v2.2.2`` resolve to the same tag. For each upstream
+``@2.2.3`` and ``@v2.2.3`` resolve to the same tag. For each upstream
 the command fetches ``packages/packages.json`` from
 ``raw.githubusercontent.com`` at tag ``v<version>`` and compares
 against any local ``third_party`` entries.
@@ -67,7 +67,7 @@ class Upstream:
         """Return the version segment used to build the tag URL.
 
         Any leading ``v`` supplied by the caller is stripped so that
-        both ``@2.2.2`` and ``@v2.2.2`` build the same URL.
+        both ``@2.2.3`` and ``@v2.2.3`` build the same URL.
 
         :return: the version string with any leading ``v`` removed.
         """
@@ -75,7 +75,7 @@ class Upstream:
 
     @property
     def display(self) -> str:
-        """Return a human-readable form, e.g. ``valory-xyz/open-aea@v2.2.2``.
+        """Return a human-readable form, e.g. ``valory-xyz/open-aea@v2.2.3``.
 
         :return: the canonical display string.
         """

--- a/plugins/aea-ci-helpers/aea_ci_helpers/cli.py
+++ b/plugins/aea-ci-helpers/aea_ci_helpers/cli.py
@@ -378,7 +378,7 @@ def check_dependencies_cmd(
     required=True,
     help=(
         "Upstream repository to verify against, as 'owner/repo@version' "
-        "(e.g. 'valory-xyz/open-aea@2.2.2'). Repeatable."
+        "(e.g. 'valory-xyz/open-aea@2.2.3'). Repeatable."
     ),
 )
 def check_third_party_hashes(root_dir: str, upstreams: tuple) -> None:

--- a/plugins/aea-ci-helpers/setup.py
+++ b/plugins/aea-ci-helpers/setup.py
@@ -31,7 +31,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ci-helpers",
-    version="2.2.2",
+    version="2.2.3",
     author="Valory AG",
     license="Apache-2.0",
     description="CI helper utilities for AEA-based projects.",

--- a/plugins/aea-ci-helpers/tests/test_check_third_party_hashes.py
+++ b/plugins/aea-ci-helpers/tests/test_check_third_party_hashes.py
@@ -41,27 +41,27 @@ class TestUpstream:
 
     def test_parse_valid(self) -> None:
         """A well-formed spec yields the expected fields."""
-        u = Upstream.parse("valory-xyz/open-aea@2.2.2")
+        u = Upstream.parse("valory-xyz/open-aea@2.2.3")
         assert u.repo == "valory-xyz/open-aea"
-        assert u.version == "2.2.2"
+        assert u.version == "2.2.3"
 
     def test_tag_version_strips_leading_v(self) -> None:
-        """``@v2.2.2`` and ``@2.2.2`` build the same tag URL."""
-        assert Upstream("o/r", "v2.2.2").tag_version == "2.2.2"
-        assert Upstream("o/r", "2.2.2").tag_version == "2.2.2"
+        """``@v2.2.3`` and ``@2.2.3`` build the same tag URL."""
+        assert Upstream("o/r", "v2.2.3").tag_version == "2.2.3"
+        assert Upstream("o/r", "2.2.3").tag_version == "2.2.3"
 
     def test_display_always_shows_v(self) -> None:
         """The human-readable form is consistent regardless of input."""
-        assert Upstream("o/r", "2.2.2").display == "o/r@v2.2.2"
-        assert Upstream("o/r", "v2.2.2").display == "o/r@v2.2.2"
+        assert Upstream("o/r", "2.2.3").display == "o/r@v2.2.3"
+        assert Upstream("o/r", "v2.2.3").display == "o/r@v2.2.3"
 
     @pytest.mark.parametrize(
         "spec",
         [
             "no-at-sign",
-            "@2.2.2",
+            "@2.2.3",
             "valory-xyz/open-aea@",
-            "noslash@2.2.2",
+            "noslash@2.2.3",
         ],
     )
     def test_parse_invalid(self, spec: str) -> None:
@@ -98,7 +98,7 @@ class TestFetchUpstreamPackages:
 
     def test_builds_expected_url(self) -> None:
         """The tag URL uses the stripped version with a leading ``v``."""
-        upstream = Upstream("valory-xyz/open-aea", "v2.2.2")
+        upstream = Upstream("valory-xyz/open-aea", "v2.2.3")
         with mock.patch(
             "aea_ci_helpers.check_third_party_hashes.http_requests.get",
             return_value=self._mock_response(json_data={"dev": {}}),
@@ -107,7 +107,7 @@ class TestFetchUpstreamPackages:
         called_url = get.call_args.args[0]
         assert called_url == (
             "https://raw.githubusercontent.com/valory-xyz/open-aea/"
-            "v2.2.2/packages/packages.json"
+            "v2.2.3/packages/packages.json"
         )
 
     def test_non_200_raises(self) -> None:
@@ -223,7 +223,7 @@ class TestCheckHashes:
         """No mismatches or missing when local hashes match upstream."""
         local = {"protocol/valory/abci/0.1.0": "bafyA"}
         upstream_maps = self._maps(
-            ("valory-xyz/open-aea@v2.2.2", {"protocol/valory/abci/0.1.0": "bafyA"}),
+            ("valory-xyz/open-aea@v2.2.3", {"protocol/valory/abci/0.1.0": "bafyA"}),
         )
         mismatches, missing = check_hashes(local, upstream_maps)
         assert mismatches == []
@@ -234,7 +234,7 @@ class TestCheckHashes:
         local = {"protocol/valory/abci/0.1.0": "bafyLOCAL"}
         upstream_maps = self._maps(
             (
-                "valory-xyz/open-aea@v2.2.2",
+                "valory-xyz/open-aea@v2.2.3",
                 {"protocol/valory/abci/0.1.0": "bafyREMOTE"},
             ),
         )
@@ -244,7 +244,7 @@ class TestCheckHashes:
                 "protocol/valory/abci/0.1.0",
                 "bafyLOCAL",
                 "bafyREMOTE",
-                "valory-xyz/open-aea@v2.2.2",
+                "valory-xyz/open-aea@v2.2.3",
             )
         ]
         assert missing == []
@@ -253,7 +253,7 @@ class TestCheckHashes:
         """A package absent from every upstream is reported as missing."""
         local = {"protocol/valory/orphan/0.1.0": "bafyX"}
         upstream_maps = self._maps(
-            ("valory-xyz/open-aea@v2.2.2", {}),
+            ("valory-xyz/open-aea@v2.2.3", {}),
             ("other/repo@v1.0.0", {}),
         )
         mismatches, missing = check_hashes(local, upstream_maps)
@@ -264,7 +264,7 @@ class TestCheckHashes:
         """A match in *any* upstream is enough; no mismatch reported."""
         local = {"protocol/valory/abci/0.1.0": "bafyA"}
         upstream_maps = self._maps(
-            ("valory-xyz/open-aea@v2.2.2", {"protocol/valory/abci/0.1.0": "bafyOTHER"}),
+            ("valory-xyz/open-aea@v2.2.3", {"protocol/valory/abci/0.1.0": "bafyOTHER"}),
             ("other/repo@v1.0.0", {"protocol/valory/abci/0.1.0": "bafyA"}),
         )
         mismatches, missing = check_hashes(local, upstream_maps)
@@ -293,7 +293,7 @@ class TestRun:
 
     def test_missing_local_packages_json_yields_exit_1(self, tmp_path: Path) -> None:
         """A missing local file is reported cleanly."""
-        assert run(tmp_path, ["valory-xyz/open-aea@2.2.2"]) == 1
+        assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 1
 
     def test_empty_third_party_is_ok(self, tmp_path: Path) -> None:
         """An empty ``third_party`` section succeeds without any requests."""
@@ -301,7 +301,7 @@ class TestRun:
         with mock.patch(
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
         ) as fetch:
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.2"]) == 0
+            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 0
             fetch.assert_not_called()
 
     def test_mismatch_yields_exit_1(self, tmp_path: Path) -> None:
@@ -311,7 +311,7 @@ class TestRun:
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
             return_value={"p/v/a/0.1.0": "bafyREMOTE"},
         ):
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.2"]) == 1
+            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 1
 
     def test_match_yields_exit_0(self, tmp_path: Path) -> None:
         """All hashes matching returns exit code 0."""
@@ -320,7 +320,7 @@ class TestRun:
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
             return_value={"p/v/a/0.1.0": "bafyOK"},
         ):
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.2"]) == 0
+            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 0
 
     def test_all_upstreams_unreachable_yields_exit_1(self, tmp_path: Path) -> None:
         """If no upstream is reachable, the command cannot verify and fails."""
@@ -329,7 +329,7 @@ class TestRun:
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
             side_effect=RuntimeError("network unreachable"),
         ):
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.2"]) == 1
+            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 1
 
     def test_one_unreachable_but_other_matches_is_ok(self, tmp_path: Path) -> None:
         """A flaky upstream is tolerated when another upstream succeeds."""
@@ -348,8 +348,8 @@ class TestRun:
                 run(
                     tmp_path,
                     [
-                        "flaky/mirror@2.2.2",
-                        "valory-xyz/open-aea@2.2.2",
+                        "flaky/mirror@2.2.3",
+                        "valory-xyz/open-aea@2.2.3",
                     ],
                 )
                 == 0
@@ -364,4 +364,4 @@ class TestRun:
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
             return_value={},
         ):
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.2"]) == 1
+            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 1

--- a/plugins/aea-ci-helpers/tests/test_check_third_party_hashes.py
+++ b/plugins/aea-ci-helpers/tests/test_check_third_party_hashes.py
@@ -33,6 +33,7 @@ from aea_ci_helpers.check_third_party_hashes import (
     run,
 )
 
+from aea.__version__ import __version__ as VERSION
 from aea.helpers import http_requests
 
 
@@ -41,27 +42,27 @@ class TestUpstream:
 
     def test_parse_valid(self) -> None:
         """A well-formed spec yields the expected fields."""
-        u = Upstream.parse("valory-xyz/open-aea@2.2.3")
+        u = Upstream.parse(f"valory-xyz/open-aea@{VERSION}")
         assert u.repo == "valory-xyz/open-aea"
-        assert u.version == "2.2.3"
+        assert u.version == VERSION
 
     def test_tag_version_strips_leading_v(self) -> None:
-        """``@v2.2.3`` and ``@2.2.3`` build the same tag URL."""
-        assert Upstream("o/r", "v2.2.3").tag_version == "2.2.3"
-        assert Upstream("o/r", "2.2.3").tag_version == "2.2.3"
+        """``@v<VERSION>`` and ``@<VERSION>`` build the same tag URL."""
+        assert Upstream("o/r", f"v{VERSION}").tag_version == VERSION
+        assert Upstream("o/r", VERSION).tag_version == VERSION
 
     def test_display_always_shows_v(self) -> None:
         """The human-readable form is consistent regardless of input."""
-        assert Upstream("o/r", "2.2.3").display == "o/r@v2.2.3"
-        assert Upstream("o/r", "v2.2.3").display == "o/r@v2.2.3"
+        assert Upstream("o/r", VERSION).display == f"o/r@v{VERSION}"
+        assert Upstream("o/r", f"v{VERSION}").display == f"o/r@v{VERSION}"
 
     @pytest.mark.parametrize(
         "spec",
         [
             "no-at-sign",
-            "@2.2.3",
+            f"@{VERSION}",
             "valory-xyz/open-aea@",
-            "noslash@2.2.3",
+            f"noslash@{VERSION}",
         ],
     )
     def test_parse_invalid(self, spec: str) -> None:
@@ -98,7 +99,7 @@ class TestFetchUpstreamPackages:
 
     def test_builds_expected_url(self) -> None:
         """The tag URL uses the stripped version with a leading ``v``."""
-        upstream = Upstream("valory-xyz/open-aea", "v2.2.3")
+        upstream = Upstream("valory-xyz/open-aea", f"v{VERSION}")
         with mock.patch(
             "aea_ci_helpers.check_third_party_hashes.http_requests.get",
             return_value=self._mock_response(json_data={"dev": {}}),
@@ -107,7 +108,7 @@ class TestFetchUpstreamPackages:
         called_url = get.call_args.args[0]
         assert called_url == (
             "https://raw.githubusercontent.com/valory-xyz/open-aea/"
-            "v2.2.3/packages/packages.json"
+            f"v{VERSION}/packages/packages.json"
         )
 
     def test_non_200_raises(self) -> None:
@@ -223,7 +224,7 @@ class TestCheckHashes:
         """No mismatches or missing when local hashes match upstream."""
         local = {"protocol/valory/abci/0.1.0": "bafyA"}
         upstream_maps = self._maps(
-            ("valory-xyz/open-aea@v2.2.3", {"protocol/valory/abci/0.1.0": "bafyA"}),
+            (f"valory-xyz/open-aea@v{VERSION}", {"protocol/valory/abci/0.1.0": "bafyA"}),
         )
         mismatches, missing = check_hashes(local, upstream_maps)
         assert mismatches == []
@@ -234,7 +235,7 @@ class TestCheckHashes:
         local = {"protocol/valory/abci/0.1.0": "bafyLOCAL"}
         upstream_maps = self._maps(
             (
-                "valory-xyz/open-aea@v2.2.3",
+                f"valory-xyz/open-aea@v{VERSION}",
                 {"protocol/valory/abci/0.1.0": "bafyREMOTE"},
             ),
         )
@@ -244,7 +245,7 @@ class TestCheckHashes:
                 "protocol/valory/abci/0.1.0",
                 "bafyLOCAL",
                 "bafyREMOTE",
-                "valory-xyz/open-aea@v2.2.3",
+                f"valory-xyz/open-aea@v{VERSION}",
             )
         ]
         assert missing == []
@@ -253,7 +254,7 @@ class TestCheckHashes:
         """A package absent from every upstream is reported as missing."""
         local = {"protocol/valory/orphan/0.1.0": "bafyX"}
         upstream_maps = self._maps(
-            ("valory-xyz/open-aea@v2.2.3", {}),
+            (f"valory-xyz/open-aea@v{VERSION}", {}),
             ("other/repo@v1.0.0", {}),
         )
         mismatches, missing = check_hashes(local, upstream_maps)
@@ -264,7 +265,7 @@ class TestCheckHashes:
         """A match in *any* upstream is enough; no mismatch reported."""
         local = {"protocol/valory/abci/0.1.0": "bafyA"}
         upstream_maps = self._maps(
-            ("valory-xyz/open-aea@v2.2.3", {"protocol/valory/abci/0.1.0": "bafyOTHER"}),
+            (f"valory-xyz/open-aea@v{VERSION}", {"protocol/valory/abci/0.1.0": "bafyOTHER"}),
             ("other/repo@v1.0.0", {"protocol/valory/abci/0.1.0": "bafyA"}),
         )
         mismatches, missing = check_hashes(local, upstream_maps)
@@ -293,7 +294,7 @@ class TestRun:
 
     def test_missing_local_packages_json_yields_exit_1(self, tmp_path: Path) -> None:
         """A missing local file is reported cleanly."""
-        assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 1
+        assert run(tmp_path, [f"valory-xyz/open-aea@{VERSION}"]) == 1
 
     def test_empty_third_party_is_ok(self, tmp_path: Path) -> None:
         """An empty ``third_party`` section succeeds without any requests."""
@@ -301,7 +302,7 @@ class TestRun:
         with mock.patch(
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
         ) as fetch:
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 0
+            assert run(tmp_path, [f"valory-xyz/open-aea@{VERSION}"]) == 0
             fetch.assert_not_called()
 
     def test_mismatch_yields_exit_1(self, tmp_path: Path) -> None:
@@ -311,7 +312,7 @@ class TestRun:
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
             return_value={"p/v/a/0.1.0": "bafyREMOTE"},
         ):
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 1
+            assert run(tmp_path, [f"valory-xyz/open-aea@{VERSION}"]) == 1
 
     def test_match_yields_exit_0(self, tmp_path: Path) -> None:
         """All hashes matching returns exit code 0."""
@@ -320,7 +321,7 @@ class TestRun:
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
             return_value={"p/v/a/0.1.0": "bafyOK"},
         ):
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 0
+            assert run(tmp_path, [f"valory-xyz/open-aea@{VERSION}"]) == 0
 
     def test_all_upstreams_unreachable_yields_exit_1(self, tmp_path: Path) -> None:
         """If no upstream is reachable, the command cannot verify and fails."""
@@ -329,7 +330,7 @@ class TestRun:
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
             side_effect=RuntimeError("network unreachable"),
         ):
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 1
+            assert run(tmp_path, [f"valory-xyz/open-aea@{VERSION}"]) == 1
 
     def test_one_unreachable_but_other_matches_is_ok(self, tmp_path: Path) -> None:
         """A flaky upstream is tolerated when another upstream succeeds."""
@@ -348,8 +349,8 @@ class TestRun:
                 run(
                     tmp_path,
                     [
-                        "flaky/mirror@2.2.3",
-                        "valory-xyz/open-aea@2.2.3",
+                        f"flaky/mirror@{VERSION}",
+                        f"valory-xyz/open-aea@{VERSION}",
                     ],
                 )
                 == 0
@@ -364,4 +365,4 @@ class TestRun:
             "aea_ci_helpers.check_third_party_hashes.fetch_upstream_packages",
             return_value={},
         ):
-            assert run(tmp_path, ["valory-xyz/open-aea@2.2.3"]) == 1
+            assert run(tmp_path, [f"valory-xyz/open-aea@{VERSION}"]) == 1

--- a/plugins/aea-ci-helpers/tests/test_check_third_party_hashes.py
+++ b/plugins/aea-ci-helpers/tests/test_check_third_party_hashes.py
@@ -224,7 +224,10 @@ class TestCheckHashes:
         """No mismatches or missing when local hashes match upstream."""
         local = {"protocol/valory/abci/0.1.0": "bafyA"}
         upstream_maps = self._maps(
-            (f"valory-xyz/open-aea@v{VERSION}", {"protocol/valory/abci/0.1.0": "bafyA"}),
+            (
+                f"valory-xyz/open-aea@v{VERSION}",
+                {"protocol/valory/abci/0.1.0": "bafyA"},
+            ),
         )
         mismatches, missing = check_hashes(local, upstream_maps)
         assert mismatches == []
@@ -265,7 +268,10 @@ class TestCheckHashes:
         """A match in *any* upstream is enough; no mismatch reported."""
         local = {"protocol/valory/abci/0.1.0": "bafyA"}
         upstream_maps = self._maps(
-            (f"valory-xyz/open-aea@v{VERSION}", {"protocol/valory/abci/0.1.0": "bafyOTHER"}),
+            (
+                f"valory-xyz/open-aea@v{VERSION}",
+                {"protocol/valory/abci/0.1.0": "bafyOTHER"},
+            ),
             ("other/repo@v1.0.0", {"protocol/valory/abci/0.1.0": "bafyA"}),
         )
         mismatches, missing = check_hashes(local, upstream_maps)

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-cli-benchmark",
-    version="2.2.2",
+    version="2.2.3",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -34,7 +34,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-cli-ipfs",
-    version="2.2.2",
+    version="2.2.3",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-dev-helpers/setup.py
+++ b/plugins/aea-dev-helpers/setup.py
@@ -31,7 +31,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-dev-helpers",
-    version="2.2.2",
+    version="2.2.3",
     author="Valory AG",
     license="Apache-2.0",
     description="Development and release helper utilities for AEA-based projects.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -33,7 +33,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="2.2.2",
+    version="2.2.3",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum-hwi/setup.py
+++ b/plugins/aea-ledger-ethereum-hwi/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-ethereum-hwi",
-    version="2.2.2",
+    version="2.2.3",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and support for hardware wallet interactions.",
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "open-aea>=2.0.0, <3.0.0",
         "eth-account>=0.13.0,<0.14.0",
-        "open-aea-ledger-ethereum~=2.2.2",
+        "open-aea-ledger-ethereum~=2.2.3",
         "ledgerwallet==0.1.3",
     ],
     tests_require=["pytest>=7.0,<10"],

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -33,7 +33,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="2.2.2",
+    version="2.2.3",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -37,7 +37,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="2.2.2",
+    version="2.2.3",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",
@@ -51,7 +51,7 @@ setup(
         ]
     },
     python_requires=">=3.10,<3.15",
-    install_requires=["open-aea-ledger-cosmos~=2.2.2", "requests>=2.32.5,<3"],
+    install_requires=["open-aea-ledger-cosmos~=2.2.3", "requests>=2.32.5,<3"],
     extras_require={
         "test_tools": ["pytest>=7.0,<10", "docker==7.1.0"],
     },

--- a/plugins/aea-ledger-solana/setup.py
+++ b/plugins/aea-ledger-solana/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-solana",
-    version="2.2.2",
+    version="2.2.3",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of solana.",

--- a/pylintrc.local
+++ b/pylintrc.local
@@ -6,4 +6,4 @@
 # [SPELLING]).
 
 [IMPORTS]
-ignored-modules=bech32,ecdsa,lru,eth_typing,eth_keys,eth_account,ipfshttpclient,werkzeug,openapi_spec_validator,aiohttp,multidict,yoti_python_sdk,defusedxml,fetch,matplotlib,memory_profiler,numpy,oef,openapi_core,psutil,tensorflow,temper,skimage,web3,aioprometheus,pyaes,Crypto,asn1crypto,cosmpy,google,coverage,pylint,pytest,gitpython,protobuf,docker,signal,anchorpy,cryptography.fernet,solana,solders,hexbytes,toml
+ignored-modules=aiohttp,anchorpy,asn1crypto,bech32,coverage,cosmpy,Crypto,cryptography.fernet,docker,ecdsa,eth_account,eth_keys,eth_typing,git,google,hexbytes,lru,matplotlib,memory_profiler,multidict,numpy,openapi_core,openapi_spec_validator,psutil,pyaes,pytest,signal,solana,solders,toml,web3,werkzeug

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "open-aea"
-version = "2.2.2"
+version = "2.2.3"
 description = "Open AEA Framework"
 authors = ["developer-valory <develope@valory.xyz>"]
 license = "Apache-2.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==2.2.2 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==2.2.3 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==2.2.2 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==2.2.3 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "2.2.2"
+      template: "2.2.3"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "2.2.2"
+          template: "2.2.3"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG=C.UTF-8
 RUN apt update && apt upgrade -y && apt install -y python3-dev python3-pip && apt autoremove && apt autoclean
 
 RUN pip3 install --upgrade pip
-RUN pip3 install "open-aea[all]==2.2.2" open-aea-cli-ipfs==2.2.2
+RUN pip3 install "open-aea[all]==2.2.3" open-aea-cli-ipfs==2.2.3
 
 COPY user-image/openssl.cnf /etc/ssl
 

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:2.2.2
+DOCKER_IMAGE_TAG=valory/open-aea-user:2.2.3
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Summary

Patch release on top of v2.2.2.

- **`open-aea` core** — bumps the `GitPython` floor to `>=3.1.47,<4.0.0` for upstream fixes to `GHSA-rpm5-65cw-6hj4` (insecure non-multi options accepted by `clone` / `clone_from`) and `GHSA-x2qx-6953-8485` (blind local-file-read via `git ls-remote`). #884
- **Tooling (Wave 2a/2b)** — collapses `pytest.ini`, `.pylintrc`, and the forked `.gitleaks.toml` into `pyproject.toml` + `tox.ini`; `setup.cfg` is preserved as a minimal `[isort]` stub for `aea generate-all-protocols`. Bumps `tomte` to released `==0.7.0` and points every lint testenv at `{envsitepackagesdir}/tomte/configs/<config>` instead of carrying a forked copy. The `gitleaks` job in `.github/workflows/workflow.yml` now uses tomte's canonical `gitleaks.toml` rather than gitleaks default rules. #885

No API or runtime behaviour changes — this is internal cleanup plus a security pin bump.

Release notes added to `HISTORY.md`. Upgrade guide added to `docs/upgrading.md` (covers the GitPython floor and the tomte-canonical migration for forks that mirror our `pyproject.toml`/`tox.ini`).

## Test plan

- [ ] CI green
- [ ] Manually verified locally: every linter / static-check tox env (`black-check`, `isort-check`, `flake8`, `darglint`, `vulture`, `mypy`, `pylint`, `bandit`, `safety`, `liccheck`, `check-copyright`), every consistency check (`hash-check`, `package-version-checks`, `package-dependencies-checks`, `dependencies-check`, `check-dependencies`, `check-doc-links-hashes`, `check-api-docs`), `docs`, `protolint`, plugin install smoke for all 9 plugins, and Go module build/vet/test for `aealite`, `libp2p_node`, `aea_end2end`, `aealite_agent_example`. `tox -e py3.10` unit tests = 460 passed (5 errors are `TestDirectoryHashing` which needs a local IPFS daemon — not run on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)