### PR TITLE
chore: release v2.2.4

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,19 @@
 # Release History - open AEA
 
+## 2.2.4 (2026-05-07)
+
+Plugins:
+
+- `open-aea-ledger-ethereum`: makes `RPCRotationMiddleware`'s connection-reset detection locale-safe. `classify_error` now matches on `isinstance(ConnectionResetError)`, `isinstance(ssl.SSLError)` (excluding `ssl.SSLCertVerificationError`), and `errno == 10054` (WSAECONNRESET) — and walks the `__cause__`/`__context__` chain — instead of substring-matching the localized OS message. On non-English Windows installs, transient resets that previously slipped through as `"unknown"` and skipped the retry path are now retried correctly. Resolves the `terminate_and_withdraw` HTTP 500 reported on Polystrat / Pearl. #887
+- `open-aea-ledger-ethereum`: on connection-reset errors, `RPCRotationMiddleware` now evicts the cached `requests.Session` for the affected provider (`_evict_provider_session`) before retrying, so the next attempt performs a fresh TCP/TLS handshake instead of reusing the half-closed pooled socket. The cache read and `clear()` execute under the session manager's `_lock` when one is exposed; the `_current_index` snapshot in `_handle_error_and_rotate` is taken under the middleware's own lock. Eviction failures are logged at `WARNING` with `exc_info=True` so recovery-path regressions remain diagnosable. #887
+- `open-aea-ledger-ethereum`: removes the `len(rpc_urls) > 1` gate from `RPCRotationMiddleware.wrap_make_request` — single-URL deployments (Pearl's default) now enter the retry / session-eviction loop. The retry budget remains `min(MAX_RETRIES, len(rpc_urls) * 2)`; when the configured `MAX_RETRIES` is clamped by the pool size, an INFO log line is emitted once at `build()` time. On genuine pool exhaustion a single WARNING summary is emitted before the final `raise`, distinguishing systemic outages from one-off transient failures. #887
+- `open-aea-ledger-ethereum`: changes the registration of `ExtraDataToPOAMiddleware` from `inject(layer=0)` (innermost) to `add(...)` (outermost). Required because `RPCRotationMiddleware.wrap_make_request` calls each provider directly and bypasses the inner middleware chain (formatters, ENS, retry, exception, `AttributeDictMiddleware`); PoA processing must therefore wrap the rotation layer to apply on every response. Fixes BSC `extraData` field truncation that surfaced during CI. #887
+- `open-aea-ledger-ethereum`: widens `AttributeDictTranslator.to_dict` to accept plain `dict` (`Union[AttributeDict, TxReceipt, TxData, Dict[str, Any]]`). Required because responses returning through the rotation path arrive as plain dicts rather than `AttributeDict` instances (the inner middleware chain is bypassed). `TxReceipt` and `TxData` are TypedDicts and continue to flow through the same arm. The existing `AttributeDict` callers are unaffected. #887
+
+Tests:
+
+- Reworks `ACNWithBootstrappedEntryNodesDockerImage` (the libp2p ACN docker fixture) to support a multi-container topology (bootstrap node plus two entry nodes), replacing the single-container `wait()` with a per-container port poll. Resolves flaky ACN integration tests; unrelated to the WSAECONNRESET fix but absorbed into the same release for CI continuity. #887
+
 ## 2.2.3 (2026-05-04)
 
 AEA:

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "2.2.3"
+__version__ = "2.2.4"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.3 "open-aea-cli-ipfs<3.0.0,>=2.2.3"
+RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.4 "open-aea-cli-ipfs<3.0.0,>=2.2.4"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v2.2.3/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v2.2.4/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:2.2.3
+DOCKER_IMAGE_TAG=valory/open-aea-develop:2.2.4
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,6 +9,34 @@ Below we describe the additional manual steps required to upgrade between differ
 
 ### Upgrade guide
 
+## `v2.2.3` to `v2.2.4`
+
+This is a non-breaking patch release. The fixes target the `open-aea-ledger-ethereum` RPC rotation middleware and primarily affect Windows deployments, but two changes (PoA middleware ordering and `AttributeDictTranslator.to_dict` accepting plain `dict`) are global to all Ethereum users. Both are backwards-compatible.
+
+### `open-aea-ledger-ethereum` — RPC rotation: locale-safe reset detection and session eviction
+
+`RPCRotationMiddleware` now classifies WSAECONNRESET / SSL-EOF connection resets via `isinstance` and `errno == 10054` rather than substring-matching the OS error string. Non-English Windows installs that previously fell through as `"unknown"` (skipping the retry path entirely) now retry correctly. On a connection-reset classification, the affected `HTTPProvider`'s pooled `requests.Session` is evicted before the retry so the next attempt performs a fresh TCP/TLS handshake instead of reusing the half-closed socket. The retry path also fires for single-URL deployments (the previous `len(rpc_urls) > 1` gate was removed).
+
+This is purely a behavioural improvement. No API or configuration change is required.
+
+### `open-aea-ledger-ethereum` — PoA middleware now registered as outermost layer
+
+`ExtraDataToPOAMiddleware` is now installed via `web3.middleware_onion.add(...)` (outermost) rather than `inject(..., layer=0)` (innermost). The change is required because `RPCRotationMiddleware.wrap_make_request` calls providers directly and bypasses the inner middleware chain; PoA processing must therefore wrap the rotation layer to apply to every response.
+
+Practical impact for downstream consumers: PoA chains (BSC, etc.) continue to work correctly — and BSC `extraData` truncation that surfaced under rotation is fixed. If you were programmatically inspecting `web3.middleware_onion` and asserting the PoA middleware sits at position 0, update the assertion (or look it up by name).
+
+### `open-aea-ledger-ethereum` — `AttributeDictTranslator.to_dict` accepts plain `dict`
+
+The signature was widened from `Union[AttributeDict, TxReceipt, TxData]` to `Union[AttributeDict, TxReceipt, TxData, Dict[str, Any]]`, and the runtime guard accepts `(AttributeDict, dict)`. This is required so receipts returning through the rotation path — which bypasses `AttributeDictMiddleware` and therefore arrives as plain dicts — translate correctly. Existing callers passing `AttributeDict`, `TxReceipt`, or `TxData` are unaffected; the change is additive.
+
+Downstream code that subclassed `AttributeDictTranslator` and tightened the parameter type to `AttributeDict` only should widen its override to match — otherwise mypy will reject the rotation-path call sites.
+
+### Concrete upgrade steps
+
+- `pip install --upgrade "open-aea[all]==2.2.4"` (and the same `2.2.4` pin for any `open-aea-*` plugin you use, in particular `open-aea-ledger-ethereum`).
+- `aea --version` should report `2.2.4`.
+- No agent / package / config edits are required.
+
 ## `v2.2.2` to `v2.2.3`
 
 This is a non-breaking patch release. There are no API or runtime behaviour changes; the work below is a security bump and a repo-wide lint/test config consolidation that does not affect downstream consumers.

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.3
+RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.4
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-ci-helpers/setup.py
+++ b/plugins/aea-ci-helpers/setup.py
@@ -31,7 +31,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ci-helpers",
-    version="2.2.3",
+    version="2.2.4",
     author="Valory AG",
     license="Apache-2.0",
     description="CI helper utilities for AEA-based projects.",

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-cli-benchmark",
-    version="2.2.3",
+    version="2.2.4",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -34,7 +34,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-cli-ipfs",
-    version="2.2.3",
+    version="2.2.4",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-dev-helpers/setup.py
+++ b/plugins/aea-dev-helpers/setup.py
@@ -31,7 +31,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-dev-helpers",
-    version="2.2.3",
+    version="2.2.4",
     author="Valory AG",
     license="Apache-2.0",
     description="Development and release helper utilities for AEA-based projects.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -33,7 +33,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="2.2.3",
+    version="2.2.4",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum-hwi/setup.py
+++ b/plugins/aea-ledger-ethereum-hwi/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-ethereum-hwi",
-    version="2.2.3",
+    version="2.2.4",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and support for hardware wallet interactions.",
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "open-aea>=2.0.0, <3.0.0",
         "eth-account>=0.13.0,<0.14.0",
-        "open-aea-ledger-ethereum~=2.2.3",
+        "open-aea-ledger-ethereum~=2.2.4",
         "ledgerwallet==0.1.3",
     ],
     tests_require=["pytest>=7.0,<10"],

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -33,7 +33,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="2.2.3",
+    version="2.2.4",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -37,7 +37,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="2.2.3",
+    version="2.2.4",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",
@@ -51,7 +51,7 @@ setup(
         ]
     },
     python_requires=">=3.10,<3.15",
-    install_requires=["open-aea-ledger-cosmos~=2.2.3", "requests>=2.32.5,<3"],
+    install_requires=["open-aea-ledger-cosmos~=2.2.4", "requests>=2.32.5,<3"],
     extras_require={
         "test_tools": ["pytest>=7.0,<10", "docker==7.1.0"],
     },

--- a/plugins/aea-ledger-solana/setup.py
+++ b/plugins/aea-ledger-solana/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-solana",
-    version="2.2.3",
+    version="2.2.4",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of solana.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "open-aea"
-version = "2.2.3"
+version = "2.2.4"
 description = "Open AEA Framework"
 authors = ["developer-valory <develope@valory.xyz>"]
 license = "Apache-2.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==2.2.3 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==2.2.4 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==2.2.3 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==2.2.4 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "2.2.3"
+      template: "2.2.4"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "2.2.3"
+          template: "2.2.4"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG=C.UTF-8
 RUN apt update && apt upgrade -y && apt install -y python3-dev python3-pip && apt autoremove && apt autoclean
 
 RUN pip3 install --upgrade pip
-RUN pip3 install "open-aea[all]==2.2.3" open-aea-cli-ipfs==2.2.3
+RUN pip3 install "open-aea[all]==2.2.4" open-aea-cli-ipfs==2.2.4
 
 COPY user-image/openssl.cnf /etc/ssl
 

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:2.2.3
+DOCKER_IMAGE_TAG=valory/open-aea-user:2.2.4
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Summary

- Bumps `open-aea` and every `open-aea-*` plugin to **2.2.4** (plus matching Docker images, install scripts, skaffold manifests).
- Updates `HISTORY.md` and `docs/upgrading.md` for the release.

The release contains only the changes from #887 (RPC rotation hardening for Windows WSAECONNRESET):

- **Locale-safe connection-reset detection** in `RPCRotationMiddleware.classify_error` — `isinstance` + `errno == 10054` instead of substring matching, so non-English Windows errors are no longer misclassified as `"unknown"`.
- **Session-cache eviction on retries** (`_evict_provider_session`) — clears the pooled `requests.Session` so the next attempt performs a fresh TCP/TLS handshake instead of reusing a half-closed socket. Cache mutation runs under the session manager's `_lock` when one is exposed; index snapshot in `_handle_error_and_rotate` runs under the middleware's own lock.
- **Single-URL retry path** — removed the `len(rpc_urls) > 1` gate so single-URL deployments (Pearl's default) also benefit. Capped-budget INFO log fires once at `build()`; exhaustion-summary WARNING fires before the final `raise`.
- **PoA middleware moved to outermost layer** (`add()` instead of `inject(layer=0)`) — required because `wrap_make_request` calls providers directly and bypasses the inner middleware chain. Fixes BSC `extraData` truncation under rotation.
- **`AttributeDictTranslator.to_dict` widened** to accept plain `dict` (`Union[AttributeDict, TxReceipt, TxData, Dict[str, Any]]`) so receipts arriving via the rotation path translate correctly.

This is a non-breaking patch release — `docs/upgrading.md` flags the global PoA-ordering and `to_dict` signature changes as backwards-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)