### PR TITLE
fix(rpc_rotation): refactor middleware into HTTPProvider subclass

### DIFF
--- a/docs/api/plugins/aea_ledger_ethereum/rpc_rotation.md
+++ b/docs/api/plugins/aea_ledger_ethereum/rpc_rotation.md
@@ -172,14 +172,14 @@ the active RPC URL.
 
 ```python
 @endpoint_uri.setter
-def endpoint_uri(_value: str) -> None
+def endpoint_uri(value: str) -> None
 ```
 
 No-op setter retained for parent-class compatibility.
 
 **Arguments**:
 
-- `_value`: ignored.  ``HTTPProvider.__init__`` assigns to
+- `value`: ignored.  ``HTTPProvider.__init__`` assigns to
 ``endpoint_uri`` once at construction; we accept the write so the
 parent constructor does not raise, but the active endpoint is
 always derived from ``self._rpc_urls[self._current_index]``.

--- a/docs/api/plugins/aea_ledger_ethereum/rpc_rotation.md
+++ b/docs/api/plugins/aea_ledger_ethereum/rpc_rotation.md
@@ -2,18 +2,17 @@
 
 # plugins.aea-ledger-ethereum.aea`_`ledger`_`ethereum.rpc`_`rotation
 
-RPC rotation support for EthereumApi as a web3 middleware.
+RPC rotation support for EthereumApi as a Web3 ``HTTPProvider`` subclass.
 
 When multiple RPC endpoints are provided (comma-separated), the
-:class:`RPCRotationMiddleware` automatically fails over to healthy
+:class:`RotatingHTTPProvider` automatically fails over to healthy
 endpoints on rate-limit, connection, or quota errors.  With a single
-RPC URL the middleware retries on transport failures without rotation.
+RPC URL the provider retries on transport failures without rotation.
 
-<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.MakeRequestFn"></a>
-
-#### MakeRequestFn
-
-web3 typing alias
+Implementing rotation as a provider (rather than a middleware) keeps
+the standard web3 middleware chain intact: every request runs through
+the full chain — defaults plus any user-injected middleware — and only
+the underlying transport changes when rotation occurs.
 
 <a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RETRY_DELAY"></a>
 
@@ -59,14 +58,10 @@ list of parsed RPC URL strings.
 #### classify`_`error
 
 ```python
-def classify_error(error: Exception) -> str
+def classify_error(error: Exception) -> ErrorCategory
 ```
 
 Classify an RPC error into a category.
-
-Returns one of:
-``"rate_limit"``, ``"connection"``, ``"quota"``, ``"server"``,
-``"fd_exhaustion"``, or ``"unknown"``.
 
 **Arguments**:
 
@@ -74,21 +69,25 @@ Returns one of:
 
 **Returns**:
 
-error category string.
+one of ``"rate_limit"``, ``"connection"``, ``"quota"``,
+``"server"``, ``"fd_exhaustion"``, ``"unknown"``.
 
-<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RPCRotationMiddleware"></a>
+<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RotatingHTTPProvider"></a>
 
-## RPCRotationMiddleware Objects
+## RotatingHTTPProvider Objects
 
 ```python
-class RPCRotationMiddleware(Web3MiddlewareBuilder)
+class RotatingHTTPProvider(HTTPProvider)
 ```
 
-Web3 middleware that rotates RPC endpoints on transport failures.
+:class:`~web3.HTTPProvider` that rotates RPC endpoints on transport failures.
 
 Manages a pool of :class:`~web3.HTTPProvider` instances with
 per-endpoint health tracking, automatic failover, and
-exponential-backoff retry logic.
+exponential-backoff retry logic.  Because rotation happens at the
+transport layer (inside :meth:`make_request`) rather than as a web3
+middleware, the standard middleware chain — defaults plus any
+user-injected middleware — runs untouched on every call.
 
 For **write** operations (``eth_sendRawTransaction``,
 ``eth_sendTransaction``) only clear pre-send connection failures are
@@ -96,62 +95,36 @@ retried to prevent double-submission.
 
 Usage::
 
-    rpc_rotation = RPCRotationMiddleware.build(
-        w3,
+    provider = RotatingHTTPProvider(
         rpc_urls=["https://rpc1.example.com", "https://rpc2.example.com"],
         request_kwargs={"timeout": 10},
         chain_id=100,
     )
-    web3.middleware_onion.add(rpc_rotation)
+    w3 = Web3(provider)
 
-<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RPCRotationMiddleware.build"></a>
+<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RotatingHTTPProvider.__init__"></a>
 
-#### build
+#### `__`init`__`
 
 ```python
-@classmethod
-def build(cls,
-          w3: Union[AsyncWeb3, Web3],
-          rpc_urls: List[str],
-          request_kwargs: Optional[Dict[str, Any]] = None,
-          chain_id: Optional[int] = None) -> "RPCRotationMiddleware"
+def __init__(rpc_urls: List[str],
+             request_kwargs: Optional[Dict[str, Any]] = None,
+             chain_id: Optional[int] = None) -> None
 ```
 
-Build the middleware.
+Initialize the rotating provider.
 
 **Arguments**:
 
-- `w3`: the Web3 instance.
-- `rpc_urls`: list of RPC endpoint URL strings (required).
-- `request_kwargs`: dict forwarded to each HTTPProvider.
+- `rpc_urls`: list of RPC endpoint URL strings (required, non-empty).
+- `request_kwargs`: dict forwarded to each pooled :class:`HTTPProvider`.
 - `chain_id`: optional chain ID for Chainlist fallback enrichment.
 
-**Returns**:
+**Raises**:
 
-configured :class:`RPCRotationMiddleware` instance.
+- `ValueError`: if ``rpc_urls`` (after Chainlist enrichment) is empty.
 
-<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RPCRotationMiddleware.__call__"></a>
-
-#### `__`call`__`
-
-```python
-def __call__(w3: Any = None) -> "RPCRotationMiddleware"
-```
-
-Allow this pre-built instance to be stored directly in the middleware onion.
-
-web3's ``combine_middleware`` calls ``mw(w3)`` on each entry; returning
-``self`` ensures the already-initialised instance is reused unchanged.
-
-**Arguments**:
-
-- `w3`: web3 instance (ignored — already set on build).
-
-**Returns**:
-
-this middleware instance.
-
-<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RPCRotationMiddleware.current_rpc_url"></a>
+<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RotatingHTTPProvider.current_rpc_url"></a>
 
 #### current`_`rpc`_`url
 
@@ -162,7 +135,7 @@ def current_rpc_url() -> str
 
 Return the currently active RPC URL.
 
-<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RPCRotationMiddleware.rpc_count"></a>
+<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RotatingHTTPProvider.rpc_count"></a>
 
 #### rpc`_`count
 
@@ -173,31 +146,67 @@ def rpc_count() -> int
 
 Return the number of configured RPC endpoints.
 
-<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RPCRotationMiddleware.wrap_make_request"></a>
+<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RotatingHTTPProvider.endpoint_uri"></a>
 
-#### wrap`_`make`_`request
+#### endpoint`_`uri
 
 ```python
-def wrap_make_request(make_request: MakeRequestFn) -> MakeRequestFn
+@property
+def endpoint_uri() -> str
 ```
 
-Wrap the JSON-RPC make_request with retry and rotation logic.
+Return the URL of the currently active RPC endpoint.
 
-``make_request`` (the next function in the middleware chain) is
-intentionally not called.  Instead, this middleware calls each
-provider's ``make_request`` directly so it can retry against
-different providers in the pool without being subject to other
-middleware's retry or error-conversion logic.  As a result,
-inner middleware (formatters, ``AttributeDictMiddleware``, ENS,
-exception, retry) are bypassed on all call paths; callers must
-handle plain-dict responses.  PoA middleware must therefore be
-added as the *outermost* layer (via ``add``, not ``inject``).
-
-**Arguments**:
-
-- `make_request`: not used; present to satisfy the web3 middleware interface.
+Overrides :attr:`HTTPProvider.endpoint_uri` so that diagnostic tooling
+(metrics, logging, request IDs) reading ``w3.provider.endpoint_uri``
+observes the URL we are *currently* dispatching to rather than the
+URL passed to ``super().__init__``.
 
 **Returns**:
 
-wrapped make_request function.
+the active RPC URL.
+
+<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RotatingHTTPProvider.endpoint_uri"></a>
+
+#### endpoint`_`uri
+
+```python
+@endpoint_uri.setter
+def endpoint_uri(_value: str) -> None
+```
+
+No-op setter retained for parent-class compatibility.
+
+**Arguments**:
+
+- `_value`: ignored.  ``HTTPProvider.__init__`` assigns to
+``endpoint_uri`` once at construction; we accept the write so the
+parent constructor does not raise, but the active endpoint is
+always derived from ``self._rpc_urls[self._current_index]``.
+
+<a id="plugins.aea-ledger-ethereum.aea_ledger_ethereum.rpc_rotation.RotatingHTTPProvider.make_request"></a>
+
+#### make`_`request
+
+```python
+def make_request(method: RPCEndpoint, params: Any) -> RPCResponse
+```
+
+Dispatch a JSON-RPC call with rotation and retry across the pool.
+
+Each attempt routes to the currently-active pooled provider.  On a
+retryable transport failure the offending provider is marked unhealthy,
+rotation advances to the next healthy peer, and the call is retried
+(with exponential backoff) until the per-call retry budget is
+exhausted.  Write methods are retried only on clear pre-send failures
+so a partially-submitted transaction is never re-broadcast.
+
+**Arguments**:
+
+- `method`: JSON-RPC method name.
+- `params`: JSON-RPC parameters.
+
+**Returns**:
+
+the JSON-RPC response.
 

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -703,7 +703,10 @@ class AttributeDictTranslator:
         # TxReceipt / TxData are TypedDicts (dict subclasses), so accept both
         # AttributeDict and plain dict.
         if not isinstance(attr_dict, (AttributeDict, dict)):
-            raise ValueError("No AttributeDict provided.")  # pragma: nocover
+            raise ValueError(  # pragma: nocover
+                f"Expected AttributeDict or dict-like, "
+                f"got {type(attr_dict).__name__}"
+            )
         result = {
             cls._valid_key(key): cls._remove_hexbytes(value)
             for key, value in attr_dict.items()

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/ethereum.py
@@ -34,7 +34,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from uuid import uuid4
 
 import requests
-from aea_ledger_ethereum.rpc_rotation import RPCRotationMiddleware, parse_rpc_urls
+from aea_ledger_ethereum.rpc_rotation import RotatingHTTPProvider, parse_rpc_urls
 from eth_account import Account
 from eth_account._utils.legacy_transactions import (
     encode_transaction,
@@ -51,7 +51,7 @@ from requests import HTTPError
 from requests.exceptions import ReadTimeout as RequestsReadTimeoutError
 from toolz import curry  # type: ignore  # pylint: disable=import-error
 from urllib3.exceptions import ReadTimeoutError as Urllib3ReadTimeoutError
-from web3 import AsyncWeb3, HTTPProvider, Web3
+from web3 import AsyncWeb3, Web3
 from web3._utils.events import EventFilterBuilder
 from web3._utils.http import DEFAULT_HTTP_TIMEOUT
 from web3.contract.contract import ContractEvent
@@ -700,12 +700,8 @@ class AttributeDictTranslator:
         cls, attr_dict: Union[AttributeDict, TxReceipt, TxData, Dict[str, Any]]
     ) -> JSONLike:
         """Simplify to dict."""
-        # Plain dict is accepted in addition to AttributeDict because
-        # RPCRotationMiddleware calls self._providers[i].make_request() directly,
-        # bypassing the inner web3 middleware chain (including AttributeDictMiddleware).
-        # Responses on the rotation path therefore arrive as plain dicts rather than
-        # AttributeDict instances.  TxReceipt / TxData are TypedDicts (dict subclasses)
-        # and handled identically.
+        # TxReceipt / TxData are TypedDicts (dict subclasses), so accept both
+        # AttributeDict and plain dict.
         if not isinstance(attr_dict, (AttributeDict, dict)):
             raise ValueError("No AttributeDict provided.")  # pragma: nocover
         result = {
@@ -1114,20 +1110,16 @@ class EthereumApi(LedgerApi, EthereumHelper):
         request_kwargs = {
             REQUESTS_TIMEOUT_KEY: kwargs.pop(REQUESTS_TIMEOUT_KEY, DEFAULT_HTTP_TIMEOUT)
         }
-        self._api = Web3(
-            HTTPProvider(
-                endpoint_uri=rpc_urls[0],
-                request_kwargs=request_kwargs,
-            )
-        )
-        # RPC rotation middleware — handles failover and retry across endpoints
-        self._rpc_rotation: RPCRotationMiddleware = RPCRotationMiddleware.build(
-            self._api,
+        # RotatingHTTPProvider handles failover and retry across endpoints at
+        # the transport layer.  Because rotation lives inside the provider
+        # rather than as a middleware, the standard web3 middleware chain runs
+        # untouched on every call — defaults plus any user-injected middleware.
+        self._rpc_rotation = RotatingHTTPProvider(
             rpc_urls=rpc_urls,
             request_kwargs=request_kwargs,
             chain_id=self._chain_id,
         )
-        self._api.middleware_onion.add(self._rpc_rotation)
+        self._api = Web3(self._rpc_rotation)
         # cache the chain id and use it for all the `eth_chainId` calls to avoid excess RPC usage
         cached_chain_id = (
             CachedChainIdMiddleware.build(  # pylint: disable=no-value-for-parameter
@@ -1153,12 +1145,8 @@ class EthereumApi(LedgerApi, EthereumHelper):
         self._poa_chain = kwargs.pop("poa_chain", False)
         if self._poa_chain:
             # https://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority
-            # Must be added as the outermost middleware so that its response transformation
-            # (truncating the oversized extraData field) is applied even when
-            # RPCRotationMiddleware routes requests to rotation providers directly,
-            # bypassing the inner middleware chain.
-            self._api.middleware_onion.add(
-                ExtraDataToPOAMiddleware, name="ExtraDataToPOAMiddleware"
+            self._api.middleware_onion.inject(
+                ExtraDataToPOAMiddleware, name="ExtraDataToPOAMiddleware", layer=0
             )
             _default_logger.info(
                 "EthereumApi has been configured with Proof of Authority chain support"

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/rpc_rotation.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/rpc_rotation.py
@@ -17,12 +17,17 @@
 #
 # ------------------------------------------------------------------------------
 
-"""RPC rotation support for EthereumApi as a web3 middleware.
+"""RPC rotation support for EthereumApi as a Web3 ``HTTPProvider`` subclass.
 
 When multiple RPC endpoints are provided (comma-separated), the
-:class:`RPCRotationMiddleware` automatically fails over to healthy
+:class:`RotatingHTTPProvider` automatically fails over to healthy
 endpoints on rate-limit, connection, or quota errors.  With a single
-RPC URL the middleware retries on transport failures without rotation.
+RPC URL the provider retries on transport failures without rotation.
+
+Implementing rotation as a provider (rather than a middleware) keeps
+the standard web3 middleware chain intact: every request runs through
+the full chain — defaults plus any user-injected middleware — and only
+the underlying transport changes when rotation occurs.
 """
 
 import logging
@@ -30,16 +35,21 @@ import ssl
 import threading
 import time
 from contextlib import nullcontext
-from typing import Any, Dict, FrozenSet, List, Optional, Union
+from typing import Any, Dict, FrozenSet, List, Literal, Optional
 
 from aea_ledger_ethereum.chainlist import enrich_rpc_urls
-from web3 import AsyncWeb3, HTTPProvider, Web3
-from web3.middleware.base import Web3MiddlewareBuilder
+from web3 import HTTPProvider
 from web3.types import RPCEndpoint, RPCResponse
 
-_logger = logging.getLogger("aea.ledger_apis.ethereum.rpc_rotation")
+# Closed set of error categories returned by :func:`classify_error`.  Using a
+# ``Literal`` keeps the stringly-typed switches in ``make_request`` and
+# ``_handle_error_and_rotate`` checkable by mypy and prevents future
+# maintainers from adding a category without updating every call site.
+ErrorCategory = Literal[
+    "rate_limit", "connection", "quota", "server", "fd_exhaustion", "unknown"
+]
 
-MakeRequestFn = Any  # web3 typing alias
+_logger = logging.getLogger("aea.ledger_apis.ethereum.rpc_rotation")
 
 # ---------------------------------------------------------------------------
 # Write RPC methods — retried only on clear pre-send failures
@@ -172,15 +182,12 @@ def _is_connection_reset(error: BaseException) -> bool:
     return False
 
 
-def classify_error(error: Exception) -> str:
+def classify_error(error: Exception) -> ErrorCategory:
     """Classify an RPC error into a category.
 
-    Returns one of:
-    ``"rate_limit"``, ``"connection"``, ``"quota"``, ``"server"``,
-    ``"fd_exhaustion"``, or ``"unknown"``.
-
     :param error: the exception raised by the RPC call.
-    :return: error category string.
+    :return: one of ``"rate_limit"``, ``"connection"``, ``"quota"``,
+        ``"server"``, ``"fd_exhaustion"``, ``"unknown"``.
     """
     # Locale-safe class-based checks first — English-only string matching
     # misses localized OS error messages (Spanish, Chinese WSAECONNRESET text).
@@ -203,16 +210,19 @@ def classify_error(error: Exception) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Middleware
+# Provider
 # ---------------------------------------------------------------------------
 
 
-class RPCRotationMiddleware(Web3MiddlewareBuilder):
-    """Web3 middleware that rotates RPC endpoints on transport failures.
+class RotatingHTTPProvider(HTTPProvider):
+    """:class:`~web3.HTTPProvider` that rotates RPC endpoints on transport failures.
 
     Manages a pool of :class:`~web3.HTTPProvider` instances with
     per-endpoint health tracking, automatic failover, and
-    exponential-backoff retry logic.
+    exponential-backoff retry logic.  Because rotation happens at the
+    transport layer (inside :meth:`make_request`) rather than as a web3
+    middleware, the standard middleware chain — defaults plus any
+    user-injected middleware — runs untouched on every call.
 
     For **write** operations (``eth_sendRawTransaction``,
     ``eth_sendTransaction``) only clear pre-send connection failures are
@@ -220,82 +230,66 @@ class RPCRotationMiddleware(Web3MiddlewareBuilder):
 
     Usage::
 
-        rpc_rotation = RPCRotationMiddleware.build(
-            w3,
+        provider = RotatingHTTPProvider(
             rpc_urls=["https://rpc1.example.com", "https://rpc2.example.com"],
             request_kwargs={"timeout": 10},
             chain_id=100,
         )
-        web3.middleware_onion.add(rpc_rotation)
+        w3 = Web3(provider)
     """
 
-    # Set by build()
-    _rpc_urls: List[str]
-    _request_kwargs: Dict[str, Any]
-    _providers: List[HTTPProvider]
-    _current_index: int
-    _backoff_until: Dict[int, float]
-    _lock: threading.Lock
-    _last_rotation_time: float
-
-    @classmethod
-    def build(  # pylint: disable=arguments-differ
-        cls,
-        w3: Union[AsyncWeb3, Web3],
+    def __init__(
+        self,
         rpc_urls: List[str],
         request_kwargs: Optional[Dict[str, Any]] = None,
         chain_id: Optional[int] = None,
-    ) -> "RPCRotationMiddleware":
-        """Build the middleware.
+    ) -> None:
+        """Initialize the rotating provider.
 
-        :param w3: the Web3 instance.
-        :param rpc_urls: list of RPC endpoint URL strings (required).
-        :param request_kwargs: dict forwarded to each HTTPProvider.
+        :param rpc_urls: list of RPC endpoint URL strings (required, non-empty).
+        :param request_kwargs: dict forwarded to each pooled :class:`HTTPProvider`.
         :param chain_id: optional chain ID for Chainlist fallback enrichment.
-        :return: configured :class:`RPCRotationMiddleware` instance.
+        :raises ValueError: if ``rpc_urls`` (after Chainlist enrichment) is empty.
         """
         if request_kwargs is None:
             request_kwargs = {}
 
         rpc_urls = enrich_rpc_urls(rpc_urls, chain_id=chain_id)
+        if not rpc_urls:
+            raise ValueError("RotatingHTTPProvider requires at least one RPC URL.")
 
-        mw = cls(w3)
-        mw._rpc_urls = rpc_urls  # pylint: disable=protected-access
-        mw._request_kwargs = request_kwargs  # pylint: disable=protected-access
-        mw._providers = [  # pylint: disable=protected-access
+        # Initialize the parent HTTPProvider with the first URL.  The parent's
+        # session/transport machinery is unused — every request is delegated
+        # to one of ``self._providers`` — but ``isinstance(self, HTTPProvider)``
+        # must hold so web3 treats us as a proper provider (verified against
+        # web3.py 6.x; the parent does not open any connections eagerly).
+        super().__init__(endpoint_uri=rpc_urls[0], request_kwargs=request_kwargs)
+
+        self._rpc_urls: List[str] = rpc_urls
+        self._providers: List[HTTPProvider] = [
             HTTPProvider(endpoint_uri=url, request_kwargs=request_kwargs)
             for url in rpc_urls
         ]
-        mw._current_index = 0  # pylint: disable=protected-access
-        mw._backoff_until = {}  # pylint: disable=protected-access
-        mw._lock = threading.Lock()  # pylint: disable=protected-access
-        mw._last_rotation_time = 0.0  # pylint: disable=protected-access
+        self._current_index: int = 0
+        self._backoff_until: Dict[int, float] = {}
+        # Reentrant so health-tracking helpers can be called both directly
+        # (from ``_handle_error_and_rotate``) and from inside ``_rotate``,
+        # which already holds the lock when iterating candidates.
+        self._lock: threading.RLock = threading.RLock()
+        self._last_rotation_time: float = 0.0
 
         # Surface that the configured MAX_RETRIES is being clamped by the
         # (small) provider pool — common for single-URL deployments.  Logged
-        # once at build() rather than per-request to avoid log spam.
+        # once at construction rather than per-request to avoid log spam.
         uncapped_retries = len(rpc_urls) * 2
         if uncapped_retries < MAX_RETRIES:
             _logger.info(
-                "RPCRotationMiddleware: retry budget capped at %d "
+                "RotatingHTTPProvider: retry budget capped at %d "
                 "(RPC count=%d, MAX_RETRIES=%d)",
                 uncapped_retries,
                 len(rpc_urls),
                 MAX_RETRIES,
             )
-
-        return mw
-
-    def __call__(self, w3: Any = None) -> "RPCRotationMiddleware":
-        """Allow this pre-built instance to be stored directly in the middleware onion.
-
-        web3's ``combine_middleware`` calls ``mw(w3)`` on each entry; returning
-        ``self`` ensures the already-initialised instance is reused unchanged.
-
-        :param w3: web3 instance (ignored — already set on build).
-        :return: this middleware instance.
-        """
-        return self
 
     # ------------------------------------------------------------------
     # Public introspection
@@ -311,17 +305,50 @@ class RPCRotationMiddleware(Web3MiddlewareBuilder):
         """Return the number of configured RPC endpoints."""
         return len(self._rpc_urls)
 
+    @property  # type: ignore[override]
+    def endpoint_uri(self) -> str:  # type: ignore[override]
+        """Return the URL of the currently active RPC endpoint.
+
+        Overrides :attr:`HTTPProvider.endpoint_uri` so that diagnostic tooling
+        (metrics, logging, request IDs) reading ``w3.provider.endpoint_uri``
+        observes the URL we are *currently* dispatching to rather than the
+        URL passed to ``super().__init__``.
+
+        :return: the active RPC URL.
+        """
+        return self._rpc_urls[self._current_index]
+
+    @endpoint_uri.setter
+    def endpoint_uri(self, _value: str) -> None:
+        """No-op setter retained for parent-class compatibility.
+
+        :param _value: ignored.  ``HTTPProvider.__init__`` assigns to
+            ``endpoint_uri`` once at construction; we accept the write so the
+            parent constructor does not raise, but the active endpoint is
+            always derived from ``self._rpc_urls[self._current_index]``.
+        """
+
     # ------------------------------------------------------------------
     # Per-RPC health tracking
     # ------------------------------------------------------------------
 
     def _mark_rpc_backoff(self, index: int, seconds: float) -> None:
-        """Mark an RPC as temporarily unavailable for *seconds*."""
-        self._backoff_until[index] = time.monotonic() + seconds
+        """Mark an RPC as temporarily unavailable for *seconds*.
+
+        :param index: provider index in ``self._providers``.
+        :param seconds: backoff duration in seconds.
+        """
+        with self._lock:
+            self._backoff_until[index] = time.monotonic() + seconds
 
     def _is_rpc_healthy(self, index: int) -> bool:
-        """Return ``True`` if the RPC at *index* is not in backoff."""
-        return time.monotonic() >= self._backoff_until.get(index, 0.0)
+        """Return ``True`` if the RPC at *index* is not in backoff.
+
+        :param index: provider index in ``self._providers``.
+        :return: ``True`` if not in backoff (or never marked).
+        """
+        with self._lock:
+            return time.monotonic() >= self._backoff_until.get(index, 0.0)
 
     # ------------------------------------------------------------------
     # Provider rotation
@@ -415,17 +442,24 @@ class RPCRotationMiddleware(Web3MiddlewareBuilder):
     # ------------------------------------------------------------------
 
     def _handle_error_and_rotate(
-        self, error: Exception, operation: str, index: int
+        self,
+        error: Exception,
+        operation: str,
+        index: int,
+        category: Optional[ErrorCategory] = None,
     ) -> bool:
-        """Classify *error*, apply backoff, and rotate.
+        """Apply backoff and rotation for an error.
 
         :param error: the transport-level exception.
         :param operation: human-readable label for log messages.
         :param index: provider index that was active when the error occurred.
+        :param category: optional pre-computed result of :func:`classify_error`.
+            Pass-through when the caller has already classified the error to
+            avoid a redundant string scan; defaults to running the classifier.
         :return: ``True`` if the caller should retry.
         """
-        category = classify_error(error)
-
+        if category is None:
+            category = classify_error(error)
         if category == "fd_exhaustion":
             _logger.error(
                 "FD exhaustion detected — pausing ALL RPCs for %ds.",
@@ -437,6 +471,14 @@ class RPCRotationMiddleware(Web3MiddlewareBuilder):
             return True
 
         if category == "unknown":
+            # Surface the unclassified error so operators can spot novel
+            # transport issues; the caller will re-raise without retry.
+            _logger.warning(
+                "RPC #%d unclassified error during %s (will not retry): %.120s",
+                index,
+                operation,
+                str(error),
+            )
             return False
 
         if category == "connection":
@@ -457,76 +499,67 @@ class RPCRotationMiddleware(Web3MiddlewareBuilder):
         return True
 
     # ------------------------------------------------------------------
-    # wrap_make_request
+    # make_request — the rotation/retry loop
     # ------------------------------------------------------------------
 
-    def wrap_make_request(
-        self, make_request: MakeRequestFn  # pylint: disable=unused-argument
-    ) -> MakeRequestFn:
-        """Wrap the JSON-RPC make_request with retry and rotation logic.
+    def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
+        """Dispatch a JSON-RPC call with rotation and retry across the pool.
 
-        ``make_request`` (the next function in the middleware chain) is
-        intentionally not called.  Instead, this middleware calls each
-        provider's ``make_request`` directly so it can retry against
-        different providers in the pool without being subject to other
-        middleware's retry or error-conversion logic.  As a result,
-        inner middleware (formatters, ``AttributeDictMiddleware``, ENS,
-        exception, retry) are bypassed on all call paths; callers must
-        handle plain-dict responses.  PoA middleware must therefore be
-        added as the *outermost* layer (via ``add``, not ``inject``).
+        Each attempt routes to the currently-active pooled provider.  On a
+        retryable transport failure the offending provider is marked unhealthy,
+        rotation advances to the next healthy peer, and the call is retried
+        (with exponential backoff) until the per-call retry budget is
+        exhausted.  Write methods are retried only on clear pre-send failures
+        so a partially-submitted transaction is never re-broadcast.
 
-        :param make_request: not used; present to satisfy the web3 middleware interface.
-        :return: wrapped make_request function.
+        :param method: JSON-RPC method name.
+        :param params: JSON-RPC parameters.
+        :return: the JSON-RPC response.
         """
+        is_write = method in WRITE_RPC_METHODS
+        url_count = len(self._rpc_urls)
+        max_retries = min(MAX_RETRIES, url_count * 2)
 
-        def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
-            """Middleware function to override the request with."""
-            is_write = method in WRITE_RPC_METHODS
-            url_count = len(self._rpc_urls)
-            max_retries = min(MAX_RETRIES, url_count * 2)
-            last_error: Optional[Exception] = None
+        for attempt in range(max_retries + 1):
+            used_index = self._current_index  # snapshot before the call
+            try:
+                return self._providers[used_index].make_request(method, params)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                category = classify_error(exc)
 
-            for attempt in range(max_retries + 1):
-                used_index = self._current_index  # snapshot before the call
-                try:
-                    return self._providers[used_index].make_request(method, params)
-                except Exception as exc:  # pylint: disable=broad-exception-caught
-                    last_error = exc
-                    category = classify_error(exc)
+                # Write safety: only retry on clear pre-send failures
+                if is_write and category not in ("connection", "fd_exhaustion"):
+                    raise
 
-                    # Write safety: only retry on clear pre-send failures
-                    if is_write and category not in ("connection", "fd_exhaustion"):
-                        raise
-
-                    should_retry = self._handle_error_and_rotate(
-                        exc, str(method), used_index
-                    )
-                    if not should_retry:
-                        raise
-                    if attempt >= max_retries:
-                        # All retries used up across the provider pool: surface
-                        # a single summary so a systemic outage is distinguishable
-                        # from a one-off transient failure.
-                        _logger.warning(
-                            "%s: exhausted %d retries across %d provider(s); "
-                            "last error category=%s, last error=%.120s",
-                            method,
-                            max_retries,
-                            url_count,
-                            category,
-                            str(exc),
-                        )
-                        raise
-
-                    delay = min(RETRY_DELAY * (2**attempt), MAX_RETRY_DELAY)
-                    _logger.info(
-                        "%s attempt %d failed, retrying in %.1fs …",
+                should_retry = self._handle_error_and_rotate(
+                    exc, str(method), used_index, category
+                )
+                if not should_retry:
+                    raise
+                if attempt >= max_retries:
+                    # All retries used up across the provider pool: surface
+                    # a single summary so a systemic outage is distinguishable
+                    # from a one-off transient failure.
+                    _logger.warning(
+                        "%s: exhausted %d retries across %d provider(s); "
+                        "last error category=%s, last error=%.120s",
                         method,
-                        attempt + 1,
-                        delay,
+                        max_retries,
+                        url_count,
+                        category,
+                        str(exc),
                     )
-                    time.sleep(delay)
+                    raise
 
-            raise last_error  # type: ignore[misc]
+                delay = min(RETRY_DELAY * (2**attempt), MAX_RETRY_DELAY)
+                _logger.info(
+                    "%s attempt %d failed, retrying in %.1fs …",
+                    method,
+                    attempt + 1,
+                    delay,
+                )
+                time.sleep(delay)
 
-        return middleware
+        # Unreachable: ``range(max_retries + 1)`` always yields at least one
+        # iteration which either returns successfully or re-raises above.
+        raise AssertionError("unreachable: retry loop exited without returning")

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/rpc_rotation.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/rpc_rotation.py
@@ -258,19 +258,29 @@ class RotatingHTTPProvider(HTTPProvider):
         if not rpc_urls:
             raise ValueError("RotatingHTTPProvider requires at least one RPC URL.")
 
-        # Initialize the parent HTTPProvider with the first URL.  The parent's
-        # session/transport machinery is unused — every request is delegated
-        # to one of ``self._providers`` — but ``isinstance(self, HTTPProvider)``
-        # must hold so web3 treats us as a proper provider (verified against
-        # web3.py 6.x; the parent does not open any connections eagerly).
+        # Set the attributes the ``endpoint_uri`` getter reads *before*
+        # calling ``super().__init__``.  The parent constructor writes to
+        # ``self.endpoint_uri`` (which our no-op setter absorbs); some web3
+        # code paths read ``endpoint_uri`` from within the parent init —
+        # hoisting these assignments keeps the getter defensible regardless
+        # of which parent code paths are taken on a future web3 upgrade.
+        # When upgrading web3.py: re-verify ``HTTPProvider.__init__`` still
+        # does not read ``self.endpoint_uri`` after assignment, and that
+        # the rotating provider is never constructed with ``session=...``
+        # passed through (parent reads ``endpoint_uri`` in that branch).
+        self._rpc_urls: List[str] = rpc_urls
+        self._current_index: int = 0
+
+        # ``isinstance(self, HTTPProvider)`` must hold so web3 treats us
+        # as a proper provider; the parent's session/transport machinery
+        # is otherwise unused since every request is delegated to one of
+        # ``self._providers``.
         super().__init__(endpoint_uri=rpc_urls[0], request_kwargs=request_kwargs)
 
-        self._rpc_urls: List[str] = rpc_urls
         self._providers: List[HTTPProvider] = [
             HTTPProvider(endpoint_uri=url, request_kwargs=request_kwargs)
             for url in rpc_urls
         ]
-        self._current_index: int = 0
         self._backoff_until: Dict[int, float] = {}
         # Reentrant so health-tracking helpers can be called both directly
         # (from ``_handle_error_and_rotate``) and from inside ``_rotate``,
@@ -319,14 +329,22 @@ class RotatingHTTPProvider(HTTPProvider):
         return self._rpc_urls[self._current_index]
 
     @endpoint_uri.setter
-    def endpoint_uri(self, _value: str) -> None:
+    def endpoint_uri(self, value: str) -> None:
         """No-op setter retained for parent-class compatibility.
 
-        :param _value: ignored.  ``HTTPProvider.__init__`` assigns to
+        :param value: ignored.  ``HTTPProvider.__init__`` assigns to
             ``endpoint_uri`` once at construction; we accept the write so the
             parent constructor does not raise, but the active endpoint is
             always derived from ``self._rpc_urls[self._current_index]``.
         """
+        # Surface the no-op so a future caller doing
+        # ``provider.endpoint_uri = "https://override"`` can see at DEBUG
+        # level that the assignment did not change the active endpoint.
+        _logger.debug(
+            "RotatingHTTPProvider ignores endpoint_uri assignment to %r; "
+            "active URL is derived from self._rpc_urls[self._current_index]",
+            value,
+        )
 
     # ------------------------------------------------------------------
     # Per-RPC health tracking
@@ -562,4 +580,6 @@ class RotatingHTTPProvider(HTTPProvider):
 
         # Unreachable: ``range(max_retries + 1)`` always yields at least one
         # iteration which either returns successfully or re-raises above.
-        raise AssertionError("unreachable: retry loop exited without returning")
+        raise AssertionError(  # pragma: no cover
+            "unreachable: retry loop exited without returning"
+        )

--- a/plugins/aea-ledger-ethereum/aea_ledger_ethereum/rpc_rotation.py
+++ b/plugins/aea-ledger-ethereum/aea_ledger_ethereum/rpc_rotation.py
@@ -383,7 +383,15 @@ class RotatingHTTPProvider(HTTPProvider):
                 return False
 
             now = time.monotonic()
-            if now - self._last_rotation_time < ROTATION_COOLDOWN:
+            # The cooldown prevents thrashing between *healthy* providers
+            # (e.g. concurrent threads each triggering a rotation).  When
+            # the current provider is itself in backoff — which is the
+            # case immediately after ``_handle_error_and_rotate`` marks
+            # it unhealthy — refusing to rotate would just loop the
+            # next attempt back to a known-bad endpoint and burn the
+            # per-call retry budget.  Skip the cooldown in that case.
+            current_healthy = now >= self._backoff_until.get(self._current_index, 0.0)
+            if current_healthy and now - self._last_rotation_time < ROTATION_COOLDOWN:
                 return False
 
             best: Optional[int] = None

--- a/plugins/aea-ledger-ethereum/tests/test_chainlist.py
+++ b/plugins/aea-ledger-ethereum/tests/test_chainlist.py
@@ -432,49 +432,41 @@ class TestEnrichRpcUrls:
 
 
 # ---------------------------------------------------------------------------
-# Integration: RPCRotationMiddleware.build with chain_id → Chainlist enrichment
+# Integration: RotatingHTTPProvider with chain_id → Chainlist enrichment
 # ---------------------------------------------------------------------------
 
 
 class TestRotationMixinChainlistIntegration:
-    """Test that RPCRotationMiddleware enriches RPCs when chain_id is given."""
+    """Test that RotatingHTTPProvider enriches RPCs when chain_id is given."""
 
     @patch("aea_ledger_ethereum.chainlist.ChainlistRPC")
     def test_init_rotation_enriches_with_chain_id(self, mock_cl_cls: MagicMock) -> None:
-        """build() enriches RPCs when chain_id is provided."""
-        from unittest.mock import MagicMock as _MM
-
-        from aea_ledger_ethereum.rpc_rotation import RPCRotationMiddleware
+        """Test RotatingHTTPProvider enriches RPCs when chain_id is provided."""
+        from aea_ledger_ethereum.rpc_rotation import RotatingHTTPProvider
 
         mock_cl = mock_cl_cls.return_value
         mock_cl.get_validated_rpcs.return_value = ["https://extra.com"]
 
-        mock_w3 = _MM()
-        mw = RPCRotationMiddleware.build(
-            mock_w3,
+        provider = RotatingHTTPProvider(
             rpc_urls=["https://original.com"],
             request_kwargs={},
             chain_id=100,
         )
 
-        assert mw.rpc_count == 2
-        assert mw._rpc_urls == ["https://original.com", "https://extra.com"]
+        assert provider.rpc_count == 2
+        assert provider._rpc_urls == ["https://original.com", "https://extra.com"]
 
     @patch("aea_ledger_ethereum.chainlist.ChainlistRPC")
     def test_init_rotation_no_chain_id_no_enrichment(
         self, mock_cl_cls: MagicMock
     ) -> None:
-        """build() skips enrichment when no chain_id is given."""
-        from unittest.mock import MagicMock as _MM
+        """Test RotatingHTTPProvider skips enrichment when no chain_id is given."""
+        from aea_ledger_ethereum.rpc_rotation import RotatingHTTPProvider
 
-        from aea_ledger_ethereum.rpc_rotation import RPCRotationMiddleware
-
-        mock_w3 = _MM()
-        mw = RPCRotationMiddleware.build(
-            mock_w3,
+        provider = RotatingHTTPProvider(
             rpc_urls=["https://only.com"],
             request_kwargs={},
         )
 
-        assert mw.rpc_count == 1
+        assert provider.rpc_count == 1
         mock_cl_cls.assert_not_called()

--- a/plugins/aea-ledger-ethereum/tests/test_ethereum.py
+++ b/plugins/aea-ledger-ethereum/tests/test_ethereum.py
@@ -142,12 +142,11 @@ def test_attribute_dict_translator():
 
 
 def test_attribute_dict_translator_plain_dict():
-    """to_dict accepts a plain dict (e.g. from the RPCRotationMiddleware path).
+    """Test to_dict accepts a plain dict in addition to AttributeDict.
 
-    RPCRotationMiddleware calls provider.make_request() directly, bypassing
-    the inner web3 middleware chain, so responses arrive as plain dicts rather
-    than AttributeDict instances.  Both arms of the isinstance guard and the
-    recursive _remove_hexbytes path must handle plain dicts correctly.
+    TxReceipt and TxData are TypedDicts (dict subclasses) so callers may
+    legitimately pass plain dicts; both arms of the isinstance guard and
+    the recursive _remove_hexbytes path must handle them correctly.
     """
     di = {
         "blockNumber": 42,
@@ -259,6 +258,104 @@ def test_api_creation_poa(ethereum_testnet_config):
     """Test api instantiation with the poa flag enabled."""
     ethereum_testnet_config["poa_chain"] = True
     assert EthereumApi(**ethereum_testnet_config), "Failed to initialise the api"
+
+
+def test_attribute_dict_wrapping_on_rotation_path(ethereum_testnet_config):
+    """Test responses routed through RotatingHTTPProvider are wrapped as AttributeDict."""
+    ethereum_api = EthereumApi(**ethereum_testnet_config)
+    fake_receipt = {
+        "blockNumber": 12345,
+        "status": 1,
+        "transactionHash": "0x" + "ab" * 32,
+        "transactionIndex": 0,
+        "blockHash": "0x" + "cd" * 32,
+        "from": "0x" + "11" * 20,
+        "to": "0x" + "22" * 20,
+        "cumulativeGasUsed": 21000,
+        "gasUsed": 21000,
+        "contractAddress": None,
+        "logs": [],
+        "logsBloom": "0x" + "00" * 256,
+        "type": "0x2",
+        "effectiveGasPrice": 1000000000,
+    }
+    # Patch every rotation provider's make_request so the rotation middleware
+    # returns the fake response without touching the network.  The default
+    # AttributeDictMiddleware (inner to rotation) must still wrap the result.
+    fake_response = {"jsonrpc": "2.0", "id": 1, "result": fake_receipt}
+    for provider in ethereum_api._rpc_rotation._providers:
+        provider.make_request = MagicMock(return_value=fake_response)
+    result = ethereum_api.api.eth.get_transaction_receipt(
+        "0x" + "ab" * 32  # type: ignore[arg-type]
+    )
+    assert isinstance(result, AttributeDict)
+    assert result.blockNumber == 12345
+
+
+def test_user_injected_middleware_runs_on_rotation_path(ethereum_testnet_config):
+    """Test user middleware injected at layer 0 still runs through the rotation path."""
+    from web3.middleware import Web3Middleware  # local import — test-only
+
+    seen = []
+
+    class SpyMiddleware(Web3Middleware):
+        def request_processor(self, method, params):
+            seen.append(("req", method))
+            return method, params
+
+        def response_processor(self, method, response):
+            seen.append(("resp", method))
+            return response
+
+    ethereum_api = EthereumApi(**ethereum_testnet_config)
+    ethereum_api.api.middleware_onion.inject(
+        SpyMiddleware, name="SpyMiddleware", layer=0
+    )
+    fake_response = {"jsonrpc": "2.0", "id": 1, "result": "0x2a"}
+    for provider in ethereum_api._rpc_rotation._providers:
+        provider.make_request = MagicMock(return_value=fake_response)
+    ethereum_api.api.eth.get_block_number()
+    assert ("req", "eth_blockNumber") in seen
+    assert ("resp", "eth_blockNumber") in seen
+
+
+def test_poa_middleware_transforms_response_on_rotation_path(ethereum_testnet_config):
+    """Test ExtraDataToPOAMiddleware truncates extraData on the rotation path."""
+    ethereum_testnet_config["poa_chain"] = True
+    ethereum_api = EthereumApi(**ethereum_testnet_config)
+    # PoA's response_processor renames extraData -> proofOfAuthorityData on
+    # eth_getBlockByNumber.  Use an oversized extraData (>32 bytes) which web3's
+    # default formatters would reject, but PoA's transform should normalize.
+    fake_block = {
+        "number": "0x1",
+        "hash": "0x" + "ab" * 32,
+        "parentHash": "0x" + "cd" * 32,
+        "extraData": "0x" + "ee" * 64,  # 64-byte extraData (PoA-style)
+        "miner": "0x" + "11" * 20,
+        "difficulty": "0x0",
+        "totalDifficulty": "0x0",
+        "size": "0x100",
+        "gasLimit": "0x1c9c380",
+        "gasUsed": "0x0",
+        "timestamp": "0x0",
+        "transactions": [],
+        "uncles": [],
+        "logsBloom": "0x" + "00" * 256,
+        "sha3Uncles": "0x" + "00" * 32,
+        "stateRoot": "0x" + "00" * 32,
+        "transactionsRoot": "0x" + "00" * 32,
+        "receiptsRoot": "0x" + "00" * 32,
+        "mixHash": "0x" + "00" * 32,
+        "nonce": "0x0000000000000000",
+        "baseFeePerGas": "0x0",
+    }
+    fake_response = {"jsonrpc": "2.0", "id": 1, "result": fake_block}
+    for provider in ethereum_api._rpc_rotation._providers:
+        provider.make_request = MagicMock(return_value=fake_response)
+    # Should not raise — without PoA middleware running, web3's default
+    # formatter would reject the oversized extraData field.
+    block = ethereum_api.api.eth.get_block(1)
+    assert block is not None
 
 
 def test_api_none(ethereum_testnet_config):

--- a/plugins/aea-ledger-ethereum/tests/test_rpc_rotation.py
+++ b/plugins/aea-ledger-ethereum/tests/test_rpc_rotation.py
@@ -321,6 +321,38 @@ class TestRotate:
         provider._rotate()
         assert provider._rotate() is False
 
+    def test_cooldown_bypassed_when_current_unhealthy(self) -> None:
+        """Cooldown does not block rotation when the current provider is in backoff.
+
+        Regression test: the cooldown is meant to prevent thrashing among
+        healthy providers; if the active one was just marked unhealthy,
+        refusing to rotate would loop the next attempt back to a known-bad
+        endpoint and burn the per-call retry budget.
+        """
+        provider = _make_provider(["http://a", "http://b", "http://c"])
+        # First rotation: A -> B.  Sets _last_rotation_time = now.
+        assert provider._rotate() is True
+        assert provider._current_index == 1
+
+        # Within the cooldown window, mark B (the new current) unhealthy.
+        provider._mark_rpc_backoff(1, 100.0)
+
+        # Rotation must proceed despite cooldown — current is unhealthy and
+        # a healthy peer (C) exists.
+        assert provider._rotate() is True
+        assert provider._current_index == 2
+
+    def test_cooldown_still_enforced_when_current_healthy(self) -> None:
+        """Cooldown still suppresses cascades when the current provider is healthy."""
+        provider = _make_provider(["http://a", "http://b", "http://c"])
+        # First rotation: A -> B.  B remains healthy.
+        assert provider._rotate() is True
+        assert provider._current_index == 1
+        # Second rotation within cooldown window must be blocked because the
+        # current provider is healthy (so we are not stuck on a dead RPC).
+        assert provider._rotate() is False
+        assert provider._current_index == 1
+
     def test_all_in_backoff_picks_soonest_expiry(self) -> None:
         """When all RPCs are in backoff, picks the one expiring soonest."""
         provider = _make_provider(["http://a", "http://b", "http://c"])

--- a/plugins/aea-ledger-ethereum/tests/test_rpc_rotation.py
+++ b/plugins/aea-ledger-ethereum/tests/test_rpc_rotation.py
@@ -17,7 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Tests for the RPC rotation middleware (no Ganache required)."""
+"""Tests for the rotating HTTP provider (no Ganache required)."""
 
 import ssl
 import time
@@ -29,7 +29,7 @@ from aea_ledger_ethereum.rpc_rotation import (
     CONNECTION_ERROR_BACKOFF,
     QUOTA_EXCEEDED_BACKOFF,
     RATE_LIMIT_BACKOFF,
-    RPCRotationMiddleware,
+    RotatingHTTPProvider,
     SERVER_ERROR_BACKOFF,
     _is_connection_reset,
     classify_error,
@@ -216,49 +216,46 @@ class TestClassifyErrorLocaleSafe:
 
 
 # ---------------------------------------------------------------------------
-# RPCRotationMiddleware helpers to build test instances
+# RotatingHTTPProvider helpers to build test instances
 # ---------------------------------------------------------------------------
 
 
-def _make_middleware(rpc_urls, request_kwargs=None):
-    """Build an RPCRotationMiddleware with a mock web3 instance."""
-    mock_w3 = MagicMock()
+def _make_provider(rpc_urls, request_kwargs=None):
+    """Build a RotatingHTTPProvider, bypassing Chainlist enrichment."""
     with patch(
         "aea_ledger_ethereum.rpc_rotation.enrich_rpc_urls",
         side_effect=lambda urls, **kw: urls,
     ):
-        mw = RPCRotationMiddleware.build(
-            mock_w3,
+        return RotatingHTTPProvider(
             rpc_urls=rpc_urls,
             request_kwargs=request_kwargs or {},
         )
-    return mw
 
 
 # ---------------------------------------------------------------------------
-# Build + introspection
+# Construction + introspection
 # ---------------------------------------------------------------------------
 
 
-class TestRPCRotationMiddlewareBuild:
-    """Tests for build() and introspection properties."""
+class TestRotatingHTTPProviderInit:
+    """Tests for __init__ and introspection properties."""
 
     def test_single_rpc_rotation_not_performed(self) -> None:
         """With one RPC, _rotate() returns False (no actual rotation happens)."""
-        mw = _make_middleware(["http://rpc1"])
-        assert mw.rpc_count == 1
-        assert mw.current_rpc_url == "http://rpc1"
-        assert mw._rotate() is False
+        provider = _make_provider(["http://rpc1"])
+        assert provider.rpc_count == 1
+        assert provider.current_rpc_url == "http://rpc1"
+        assert provider._rotate() is False
 
     def test_multiple_rpcs_enables_rotation(self) -> None:
         """With multiple RPCs, rotation is enabled."""
-        mw = _make_middleware(["http://rpc1", "http://rpc2", "http://rpc3"])
-        assert mw.rpc_count == 3
+        provider = _make_provider(["http://rpc1", "http://rpc2", "http://rpc3"])
+        assert provider.rpc_count == 3
 
     def test_providers_created_per_url(self) -> None:
         """One HTTPProvider is created per URL."""
-        mw = _make_middleware(["http://a", "http://b"])
-        assert len(mw._providers) == 2
+        provider = _make_provider(["http://a", "http://b"])
+        assert len(provider._providers) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -271,23 +268,23 @@ class TestHealthTracking:
 
     def test_healthy_by_default(self) -> None:
         """All RPCs start as healthy."""
-        mw = _make_middleware(["http://a", "http://b"])
-        assert mw._is_rpc_healthy(0) is True
-        assert mw._is_rpc_healthy(1) is True
+        provider = _make_provider(["http://a", "http://b"])
+        assert provider._is_rpc_healthy(0) is True
+        assert provider._is_rpc_healthy(1) is True
 
     def test_backoff_marks_unhealthy(self) -> None:
         """After marking backoff, RPC is unhealthy."""
-        mw = _make_middleware(["http://a", "http://b"])
-        mw._mark_rpc_backoff(0, 100.0)
-        assert mw._is_rpc_healthy(0) is False
-        assert mw._is_rpc_healthy(1) is True
+        provider = _make_provider(["http://a", "http://b"])
+        provider._mark_rpc_backoff(0, 100.0)
+        assert provider._is_rpc_healthy(0) is False
+        assert provider._is_rpc_healthy(1) is True
 
     def test_backoff_expires(self) -> None:
         """After backoff expires, RPC is healthy again."""
-        mw = _make_middleware(["http://a", "http://b"])
-        mw._mark_rpc_backoff(0, 0.01)
+        provider = _make_provider(["http://a", "http://b"])
+        provider._mark_rpc_backoff(0, 0.01)
         time.sleep(0.02)
-        assert mw._is_rpc_healthy(0) is True
+        assert provider._is_rpc_healthy(0) is True
 
 
 # ---------------------------------------------------------------------------
@@ -300,38 +297,38 @@ class TestRotate:
 
     def test_no_rotation_with_single_rpc(self) -> None:
         """Single RPC never rotates."""
-        mw = _make_middleware(["http://only"])
-        assert mw._rotate() is False
+        provider = _make_provider(["http://only"])
+        assert provider._rotate() is False
 
     def test_rotation_selects_next_healthy(self) -> None:
         """Rotation picks the next healthy RPC in round-robin."""
-        mw = _make_middleware(["http://a", "http://b", "http://c"])
-        assert mw._current_index == 0
-        assert mw._rotate() is True
-        assert mw._current_index == 1
-        assert mw.current_rpc_url == "http://b"
+        provider = _make_provider(["http://a", "http://b", "http://c"])
+        assert provider._current_index == 0
+        assert provider._rotate() is True
+        assert provider._current_index == 1
+        assert provider.current_rpc_url == "http://b"
 
     def test_rotation_skips_unhealthy(self) -> None:
         """Rotation skips RPCs in backoff."""
-        mw = _make_middleware(["http://a", "http://b", "http://c"])
-        mw._mark_rpc_backoff(1, 300.0)
-        mw._rotate()
-        assert mw._current_index == 2
+        provider = _make_provider(["http://a", "http://b", "http://c"])
+        provider._mark_rpc_backoff(1, 300.0)
+        provider._rotate()
+        assert provider._current_index == 2
 
     def test_rotation_cooldown(self) -> None:
         """Cannot rotate again within cooldown period."""
-        mw = _make_middleware(["http://a", "http://b"])
-        mw._rotate()
-        assert mw._rotate() is False
+        provider = _make_provider(["http://a", "http://b"])
+        provider._rotate()
+        assert provider._rotate() is False
 
     def test_all_in_backoff_picks_soonest_expiry(self) -> None:
         """When all RPCs are in backoff, picks the one expiring soonest."""
-        mw = _make_middleware(["http://a", "http://b", "http://c"])
+        provider = _make_provider(["http://a", "http://b", "http://c"])
         now = time.monotonic()
-        mw._backoff_until[1] = now + 100
-        mw._backoff_until[2] = now + 10
-        mw._rotate()
-        assert mw._current_index == 2
+        provider._backoff_until[1] = now + 100
+        provider._backoff_until[2] = now + 10
+        provider._rotate()
+        assert provider._current_index == 2
 
 
 # ---------------------------------------------------------------------------
@@ -344,37 +341,40 @@ class TestHandleErrorAndRotate:
 
     def test_unknown_error_no_retry(self) -> None:
         """Unknown errors don't trigger retry."""
-        mw = _make_middleware(["http://a", "http://b"])
+        provider = _make_provider(["http://a", "http://b"])
         assert (
-            mw._handle_error_and_rotate(Exception("something weird"), "op", 0) is False
+            provider._handle_error_and_rotate(Exception("something weird"), "op", 0)
+            is False
         )
 
     def test_rate_limit_triggers_backoff_and_rotation(self) -> None:
         """Rate limit backs off current RPC and rotates."""
-        mw = _make_middleware(["http://a", "http://b"])
+        provider = _make_provider(["http://a", "http://b"])
         assert (
-            mw._handle_error_and_rotate(Exception("429 Too Many Requests"), "op", 0)
+            provider._handle_error_and_rotate(
+                Exception("429 Too Many Requests"), "op", 0
+            )
             is True
         )
-        assert mw._is_rpc_healthy(0) is False
-        assert mw._current_index == 1
+        assert provider._is_rpc_healthy(0) is False
+        assert provider._current_index == 1
 
     def test_fd_exhaustion_backs_off_all_rpcs(self) -> None:
         """FD exhaustion marks ALL RPCs as unhealthy."""
-        mw = _make_middleware(["http://a", "http://b", "http://c"])
-        mw._handle_error_and_rotate(Exception("too many open files"), "op", 0)
-        assert mw._is_rpc_healthy(0) is False
-        assert mw._is_rpc_healthy(1) is False
-        assert mw._is_rpc_healthy(2) is False
+        provider = _make_provider(["http://a", "http://b", "http://c"])
+        provider._handle_error_and_rotate(Exception("too many open files"), "op", 0)
+        assert provider._is_rpc_healthy(0) is False
+        assert provider._is_rpc_healthy(1) is False
+        assert provider._is_rpc_healthy(2) is False
 
 
 # ---------------------------------------------------------------------------
-# wrap_make_request — single RPC
+# make_request — single RPC
 # ---------------------------------------------------------------------------
 
 
-class TestWrapMakeRequestSingleRpc:
-    """Tests for wrap_make_request with a single RPC.
+class TestMakeRequestSingleRpc:
+    """Tests for make_request with a single RPC.
 
     Single-RPC deployments use the retry loop (calling
     self._providers[0].make_request directly) so they also benefit from
@@ -382,21 +382,19 @@ class TestWrapMakeRequestSingleRpc:
     """
 
     def test_success_via_provider(self) -> None:
-        """Single-RPC: calls provider.make_request (not inner make_request)."""
-        mw = _make_middleware(["http://only"])
-        mw._providers[0].make_request = MagicMock(return_value={"result": 42})
-        inner = MagicMock()
-        middleware_fn = mw.wrap_make_request(inner)
-        result = middleware_fn("eth_blockNumber", [])
-        mw._providers[0].make_request.assert_called_once_with("eth_blockNumber", [])
+        """Single-RPC: routes to the pooled provider's make_request."""
+        provider = _make_provider(["http://only"])
+        provider._providers[0].make_request = MagicMock(return_value={"result": 42})
+        result = provider.make_request("eth_blockNumber", [])
+        provider._providers[0].make_request.assert_called_once_with(
+            "eth_blockNumber", []
+        )
         assert result == {"result": 42}
-        # inner (next middleware) is not called — provider is used directly
-        inner.assert_not_called()
 
     @patch("aea_ledger_ethereum.rpc_rotation.time.sleep")
     def test_retries_on_connection_reset(self, mock_sleep: MagicMock) -> None:
         """Single-RPC: connection resets are retried with session eviction."""
-        mw = _make_middleware(["http://only"])
+        provider = _make_provider(["http://only"])
         call_count = 0
 
         def _make_request(method, params):
@@ -406,15 +404,14 @@ class TestWrapMakeRequestSingleRpc:
                 raise ConnectionResetError("reset")
             return {"result": "ok"}
 
-        mw._providers[0].make_request = _make_request
-        middleware_fn = mw.wrap_make_request(MagicMock())
-        result = middleware_fn("eth_blockNumber", [])
+        provider._providers[0].make_request = _make_request
+        result = provider.make_request("eth_blockNumber", [])
         assert result == {"result": "ok"}
         assert call_count == 3
 
     def test_non_retriable_error_propagates_immediately(self) -> None:
         """Single-RPC: unknown errors raise without retry."""
-        mw = _make_middleware(["http://only"])
+        provider = _make_provider(["http://only"])
         call_count = 0
 
         def _fail(method, params):
@@ -422,25 +419,24 @@ class TestWrapMakeRequestSingleRpc:
             call_count += 1
             raise TypeError("unexpected type")
 
-        mw._providers[0].make_request = _fail
-        middleware_fn = mw.wrap_make_request(MagicMock())
+        provider._providers[0].make_request = _fail
         with pytest.raises(TypeError):
-            middleware_fn("eth_blockNumber", [])
+            provider.make_request("eth_blockNumber", [])
         assert call_count == 1
 
 
 # ---------------------------------------------------------------------------
-# wrap_make_request — multi-RPC (rotation enabled)
+# make_request — multi-RPC (rotation enabled)
 # ---------------------------------------------------------------------------
 
 
-class TestWrapMakeRequestMultiRpc:
-    """Tests for wrap_make_request with multiple RPCs."""
+class TestMakeRequestMultiRpc:
+    """Tests for make_request with multiple RPCs."""
 
     @patch("aea_ledger_ethereum.rpc_rotation.time.sleep")
     def test_retries_on_rate_limit(self, mock_sleep: MagicMock) -> None:
         """Rate-limit errors are retried with rotation."""
-        mw = _make_middleware(["http://a", "http://b"])
+        provider = _make_provider(["http://a", "http://b"])
         call_count = 0
 
         def _make_request(method, params):
@@ -450,11 +446,10 @@ class TestWrapMakeRequestMultiRpc:
                 raise Exception("429 rate limit")
             return {"result": "ok"}
 
-        for provider in mw._providers:
-            provider.make_request = _make_request
+        for inner_provider in provider._providers:
+            inner_provider.make_request = _make_request
 
-        middleware_fn = mw.wrap_make_request(MagicMock())
-        result = middleware_fn("eth_blockNumber", [])
+        result = provider.make_request("eth_blockNumber", [])
         assert result == {"result": "ok"}
         assert call_count == 3
         assert mock_sleep.call_count >= 1
@@ -462,18 +457,18 @@ class TestWrapMakeRequestMultiRpc:
     @patch("aea_ledger_ethereum.rpc_rotation.time.sleep")
     def test_raises_after_max_retries(self, mock_sleep: MagicMock) -> None:
         """Raises last exception after exhausting retries."""
-        mw = _make_middleware(["http://a", "http://b"])
-        for provider in mw._providers:
-            provider.make_request = MagicMock(
+        provider = _make_provider(["http://a", "http://b"])
+        for inner_provider in provider._providers:
+            inner_provider.make_request = MagicMock(
                 side_effect=Exception("connection refused")
             )
-        middleware_fn = mw.wrap_make_request(MagicMock())
+
         with pytest.raises(Exception, match="connection refused"):
-            middleware_fn("eth_blockNumber", [])
+            provider.make_request("eth_blockNumber", [])
 
     def test_unknown_error_not_retried(self) -> None:
         """Unknown errors raise immediately without retry."""
-        mw = _make_middleware(["http://a", "http://b"])
+        provider = _make_provider(["http://a", "http://b"])
         call_count = 0
 
         def _fail(method, params):
@@ -481,18 +476,17 @@ class TestWrapMakeRequestMultiRpc:
             call_count += 1
             raise TypeError("unexpected type")
 
-        for provider in mw._providers:
-            provider.make_request = _fail
+        for inner_provider in provider._providers:
+            inner_provider.make_request = _fail
 
-        middleware_fn = mw.wrap_make_request(MagicMock())
         with pytest.raises(TypeError):
-            middleware_fn("eth_blockNumber", [])
+            provider.make_request("eth_blockNumber", [])
         assert call_count == 1
 
     @patch("aea_ledger_ethereum.rpc_rotation.time.sleep")
     def test_write_not_retried_on_rate_limit(self, mock_sleep: MagicMock) -> None:
         """eth_sendRawTransaction is NOT retried on rate limit (write safety)."""
-        mw = _make_middleware(["http://a", "http://b"])
+        provider = _make_provider(["http://a", "http://b"])
         call_count = 0
 
         def _fail(method, params):
@@ -500,18 +494,17 @@ class TestWrapMakeRequestMultiRpc:
             call_count += 1
             raise Exception("429 rate limit")
 
-        for provider in mw._providers:
-            provider.make_request = _fail
+        for inner_provider in provider._providers:
+            inner_provider.make_request = _fail
 
-        middleware_fn = mw.wrap_make_request(MagicMock())
         with pytest.raises(Exception, match="rate limit"):
-            middleware_fn("eth_sendRawTransaction", [])
+            provider.make_request("eth_sendRawTransaction", [])
         assert call_count == 1
 
     @patch("aea_ledger_ethereum.rpc_rotation.time.sleep")
     def test_write_retried_on_connection_error(self, mock_sleep: MagicMock) -> None:
         """eth_sendRawTransaction IS retried on connection errors."""
-        mw = _make_middleware(["http://a", "http://b"])
+        provider = _make_provider(["http://a", "http://b"])
         call_count = 0
 
         def _make_request(method, params):
@@ -521,93 +514,115 @@ class TestWrapMakeRequestMultiRpc:
                 raise Exception("connection refused")
             return {"result": "0xtxhash"}
 
-        for provider in mw._providers:
-            provider.make_request = _make_request
+        for inner_provider in provider._providers:
+            inner_provider.make_request = _make_request
 
-        middleware_fn = mw.wrap_make_request(MagicMock())
-        result = middleware_fn("eth_sendRawTransaction", [])
+        result = provider.make_request("eth_sendRawTransaction", [])
         assert result == {"result": "0xtxhash"}
         assert call_count == 3
 
     def test_success_on_first_try(self) -> None:
         """Successful first call returns immediately."""
-        mw = _make_middleware(["http://a", "http://b"])
-        for provider in mw._providers:
-            provider.make_request = MagicMock(return_value={"result": 123})
-        middleware_fn = mw.wrap_make_request(MagicMock())
-        assert middleware_fn("eth_blockNumber", []) == {"result": 123}
+        provider = _make_provider(["http://a", "http://b"])
+        for inner_provider in provider._providers:
+            inner_provider.make_request = MagicMock(return_value={"result": 123})
+
+        assert provider.make_request("eth_blockNumber", []) == {"result": 123}
+
+    @patch("aea_ledger_ethereum.rpc_rotation.time.sleep")
+    def test_eth_send_transaction_not_retried_on_rate_limit(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """eth_sendTransaction (not just eth_sendRawTransaction) is write-protected."""
+        provider = _make_provider(["http://a", "http://b"])
+        call_count = 0
+
+        def _fail(method, params):
+            nonlocal call_count
+            call_count += 1
+            raise Exception("429 rate limit")
+
+        for inner_provider in provider._providers:
+            inner_provider.make_request = _fail
+
+        with pytest.raises(Exception, match="rate limit"):
+            provider.make_request("eth_sendTransaction", [])
+        assert call_count == 1
+
+    @patch("aea_ledger_ethereum.rpc_rotation.time.sleep")
+    def test_wsaeconnreset_rotates_to_next_provider(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """Test Windows WSAECONNRESET (errno 10054) on RPC #0 rotates to RPC #1."""
+        provider = _make_provider(["http://a", "http://b"])
+        attempts: list = []
+
+        def _make_request_a(method, params):
+            attempts.append(("a", method))
+            err = OSError()
+            err.errno = 10054  # WSAECONNRESET
+            raise err
+
+        def _make_request_b(method, params):
+            attempts.append(("b", method))
+            return {"result": "ok"}
+
+        provider._providers[0].make_request = _make_request_a
+        provider._providers[1].make_request = _make_request_b
+
+        result = provider.make_request("eth_blockNumber", [])
+        assert result == {"result": "ok"}
+        # First attempt hit provider 'a' and reset, second hit 'b' and succeeded.
+        assert attempts[0] == ("a", "eth_blockNumber")
+        assert ("b", "eth_blockNumber") in attempts
+        assert provider._current_index == 1
 
 
 # ---------------------------------------------------------------------------
-# Integration: EthereumApi uses middleware correctly
+# Integration: EthereumApi wires up the rotating provider correctly
 # ---------------------------------------------------------------------------
 
 
 class TestEthereumApiMultiRpc:
-    """Test that EthereumApi correctly sets up RPCRotationMiddleware."""
+    """Test that EthereumApi correctly sets up RotatingHTTPProvider."""
 
-    @patch("aea_ledger_ethereum.ethereum.Web3")
-    @patch("aea_ledger_ethereum.ethereum.HTTPProvider")
     @patch(
         "aea_ledger_ethereum.rpc_rotation.enrich_rpc_urls",
         side_effect=lambda urls, **kw: urls,
     )
-    def test_single_rpc_retry_path_enabled(
-        self, _mock_enrich, mock_provider_cls: MagicMock, mock_web3_cls: MagicMock
-    ) -> None:
+    def test_single_rpc_retry_path_enabled(self, _mock_enrich: MagicMock) -> None:
         """Single RPC: rotation is a no-op but retry/session-eviction path is active."""
         from aea_ledger_ethereum.ethereum import EthereumApi
 
-        mock_web3 = MagicMock()
-        mock_web3_cls.return_value = mock_web3
-        mock_web3.middleware_onion = MagicMock()
-
         api = EthereumApi(address="http://localhost:8545")
+        assert isinstance(api._rpc_rotation, RotatingHTTPProvider)
         assert api._rpc_rotation.rpc_count == 1
         assert api._rpc_rotation.current_rpc_url == "http://localhost:8545"
         # _rotate() returns False for single URL — no rotation occurs
         assert api._rpc_rotation._rotate() is False
 
-    @patch("aea_ledger_ethereum.ethereum.Web3")
-    @patch("aea_ledger_ethereum.ethereum.HTTPProvider")
     @patch(
         "aea_ledger_ethereum.rpc_rotation.enrich_rpc_urls",
         side_effect=lambda urls, **kw: urls,
     )
-    def test_multi_rpc_rotation_enabled(
-        self, _mock_enrich, mock_provider_cls: MagicMock, mock_web3_cls: MagicMock
-    ) -> None:
-        """Comma-separated RPCs: rotation middleware is enabled."""
+    def test_multi_rpc_rotation_enabled(self, _mock_enrich: MagicMock) -> None:
+        """Comma-separated RPCs: rotation across the pool is enabled."""
         from aea_ledger_ethereum.ethereum import EthereumApi
-
-        mock_web3 = MagicMock()
-        mock_web3_cls.return_value = mock_web3
-        mock_web3.middleware_onion = MagicMock()
 
         api = EthereumApi(address="http://rpc1.example.com,http://rpc2.example.com")
         assert api._rpc_rotation.rpc_count == 2
         assert api._rpc_rotation.current_rpc_url == "http://rpc1.example.com"
 
-    @patch("aea_ledger_ethereum.ethereum.Web3")
-    @patch("aea_ledger_ethereum.ethereum.HTTPProvider")
     @patch(
         "aea_ledger_ethereum.rpc_rotation.enrich_rpc_urls",
         side_effect=lambda urls, **kw: urls,
     )
-    def test_middleware_added_to_onion(
-        self, _mock_enrich, mock_provider_cls: MagicMock, mock_web3_cls: MagicMock
-    ) -> None:
-        """Test that RPCRotationMiddleware is added to the middleware onion."""
+    def test_rotating_provider_is_web3_provider(self, _mock_enrich: MagicMock) -> None:
+        """The RotatingHTTPProvider is what Web3 uses as its transport."""
         from aea_ledger_ethereum.ethereum import EthereumApi
 
-        mock_web3 = MagicMock()
-        mock_web3_cls.return_value = mock_web3
-        mock_web3.middleware_onion = MagicMock()
-
-        EthereumApi(address="http://rpc1.example.com,http://rpc2.example.com")
-        # middleware_onion.add should be called at least twice
-        # (once for RPCRotation, once for CachedChainId)
-        assert mock_web3.middleware_onion.add.call_count >= 2
+        api = EthereumApi(address="http://rpc1.example.com,http://rpc2.example.com")
+        assert api.api.provider is api._rpc_rotation
 
 
 # ---------------------------------------------------------------------------
@@ -620,37 +635,37 @@ class TestSessionCacheEvictionOnConnectionReset:
 
     def test_session_cache_cleared_on_connection_reset(self) -> None:
         """_handle_error_and_rotate clears the session cache on connection errors."""
-        mw = _make_middleware(["http://a", "http://b"])
+        provider = _make_provider(["http://a", "http://b"])
         mock_cache = MagicMock()
         mock_session_mgr = MagicMock()
         mock_session_mgr.session_cache = mock_cache
-        mw._providers[0]._request_session_manager = mock_session_mgr
+        provider._providers[0]._request_session_manager = mock_session_mgr
 
-        mw._handle_error_and_rotate(ConnectionResetError("reset"), "eth_call", 0)
+        provider._handle_error_and_rotate(ConnectionResetError("reset"), "eth_call", 0)
 
         mock_cache.clear.assert_called_once()
 
     def test_session_cache_not_cleared_on_rate_limit(self) -> None:
         """Rate-limit errors do not trigger session eviction."""
-        mw = _make_middleware(["http://a", "http://b"])
+        provider = _make_provider(["http://a", "http://b"])
         mock_cache = MagicMock()
         mock_session_mgr = MagicMock()
         mock_session_mgr.session_cache = mock_cache
-        mw._providers[0]._request_session_manager = mock_session_mgr
+        provider._providers[0]._request_session_manager = mock_session_mgr
 
-        mw._handle_error_and_rotate(Exception("429 rate limit"), "eth_call", 0)
+        provider._handle_error_and_rotate(Exception("429 rate limit"), "eth_call", 0)
 
         mock_cache.clear.assert_not_called()
 
     def test_session_eviction_survives_missing_manager(self) -> None:
         """_evict_provider_session is silent when provider has no session manager."""
-        mw = _make_middleware(["http://a"])
+        provider = _make_provider(["http://a"])
         # No _request_session_manager attribute on provider — should not raise
-        mw._evict_provider_session(0)  # must not raise
+        provider._evict_provider_session(0)  # must not raise
 
     def test_session_cache_cleared_under_lock(self) -> None:
         """cache.clear() is called while session_mgr._lock is held."""
-        mw = _make_middleware(["http://a", "http://b"])
+        provider = _make_provider(["http://a", "http://b"])
         call_order: list = []
 
         class _TrackingLock:
@@ -668,9 +683,9 @@ class TestSessionCacheEvictionOnConnectionReset:
         mock_session_mgr = MagicMock()
         mock_session_mgr.session_cache = mock_cache
         mock_session_mgr._lock = _TrackingLock()
-        mw._providers[0]._request_session_manager = mock_session_mgr
+        provider._providers[0]._request_session_manager = mock_session_mgr
 
-        mw._handle_error_and_rotate(ConnectionResetError("reset"), "eth_call", 0)
+        provider._handle_error_and_rotate(ConnectionResetError("reset"), "eth_call", 0)
 
         assert "lock_enter" in call_order
         assert "cache_clear" in call_order
@@ -693,7 +708,7 @@ class TestSingleRpcRetryPath:
         self, mock_sleep: MagicMock
     ) -> None:
         """Single URL: WSAECONNRESET triggers retry without rotation."""
-        mw = _make_middleware(["http://only"])
+        provider = _make_provider(["http://only"])
         call_count = 0
 
         def _make_request(method, params):
@@ -705,13 +720,13 @@ class TestSingleRpcRetryPath:
                 raise err
             return {"result": "ok"}
 
-        mw._providers[0].make_request = _make_request
-        middleware_fn = mw.wrap_make_request(MagicMock())
-        result = middleware_fn("eth_call", [])
+        provider._providers[0].make_request = _make_request
+
+        result = provider.make_request("eth_call", [])
         assert result == {"result": "ok"}
         assert call_count == 2
         # _rotate returned False (single URL) but retry still happened
-        assert mw._current_index == 0  # stayed on the only URL
+        assert provider._current_index == 0  # stayed on the only URL
 
 
 # ---------------------------------------------------------------------------
@@ -735,9 +750,9 @@ class TestBackoffDurations:
         self, error_msg: str, expected_backoff: float
     ) -> None:
         """Each error category applies the correct backoff duration."""
-        mw = _make_middleware(["http://a", "http://b"])
-        mw._handle_error_and_rotate(Exception(error_msg), "test", 0)
-        backoff_until = mw._backoff_until.get(0, 0.0)
+        provider = _make_provider(["http://a", "http://b"])
+        provider._handle_error_and_rotate(Exception(error_msg), "test", 0)
+        backoff_until = provider._backoff_until.get(0, 0.0)
         remaining = backoff_until - time.monotonic()
         assert remaining > 0
         assert remaining <= expected_backoff + 1.0

--- a/strategy.ini
+++ b/strategy.ini
@@ -93,7 +93,7 @@ certifi: >=2019.11.28
 ; licence is MIT, but the tool does not detect it
 attrs: >=25.4.0
 ; urllib3 is MIT licensed but tool doesn't detect it
-urllib3: ==2.6.3
+urllib3: >=2.6.3,<3
 ; click is BSD-3-Clause licensed but tool doesn't detect it
 click: <8.4.0
 ; typing-extensions is PSF licensed but tool doesn't detect it


### PR DESCRIPTION
## Why this change is needed

v2.2.4 of `open-aea-ledger-ethereum` introduced a regression where `ledger_api.api.eth.<method>(...)` calls return plain dicts instead of `AttributeDict`, breaking attribute access for downstream consumers like open-autonomy:

```python
self.tx_receipt = self.ledger_api.api.eth.wait_for_transaction_receipt(...)
while self.ledger_api.api.eth.block_number < self.tx_receipt.blockNumber:
    # AttributeError: 'dict' object has no attribute 'blockNumber'
```

### Root cause

`RPCRotationMiddleware.wrap_make_request` called pooled providers' `make_request` directly so it could retry against different providers in the pool. That call deliberately bypassed the rest of the web3 middleware chain — which also bypassed:

- `AttributeDictMiddleware` (the cause of this regression)
- `ENSNameToAddressMiddleware`
- `FormattingMiddleware`
- `BufferedGasEstimateMiddleware`
- `GasPriceStrategyMiddleware`
- **Any user-injected layer-0 middleware** (silently dead, no warning)

The 2.2.4 release patched `ExtraDataToPOAMiddleware` and `AttributeDictTranslator` defensively but left the underlying bypass in place. Every other inner middleware was silently skipped on every call.

## Why refactor from middleware to provider

A surface-level fix would be to register `AttributeDictMiddleware` as the outermost layer — but that's reactive: the same class of bug bites every default web3 middleware and any user-injected middleware. We've already missed PoA once (caught in 2.2.4) and AttributeDict once (this regression).

The deeper question is: why is rotation a middleware at all?

- **Rotation isn't request/response transformation** — it's about *which transport gets used*. The architectural home for that is the provider, not the middleware chain.
- **As a middleware, rotation had to route around itself.** Every workaround (outermost-add for PoA/AttributeDict, per-provider chain rebuilding, identity-walking the onion) was downstream of operating at the wrong abstraction level.
- **Subclassing `HTTPProvider` puts rotation *under* the entire web3 chain.** Every request runs through the full middleware stack — defaults plus any user-injected middleware — and only the underlying socket changes when rotation occurs. No bypass, no chain rebuilding, no special-casing for any middleware.
- **Smaller blast radius:** callers, tests, and middleware authors see no change to the web3 surface. `Web3(RotatingHTTPProvider(rpc_urls))` behaves identically to `Web3(HTTPProvider(url))` plus failover.

## What changed

### Core refactor (`rpc_rotation.py`)

- `RPCRotationMiddleware(Web3MiddlewareBuilder)` → `RotatingHTTPProvider(HTTPProvider)`.
- `wrap_make_request`, `__call__`, the per-provider chain cache, and the `combine_middleware`-based onion introspection are all gone. Rotation lives directly in `make_request`.

### EthereumApi (`ethereum.py`)

- `Web3(RotatingHTTPProvider(rpc_urls, ...))` instead of `Web3(HTTPProvider(...))` + middleware injection.
- `ExtraDataToPOAMiddleware` reverts to its standard placement at `inject(layer=0)`. The 2.2.4 outermost-add workaround is no longer needed.

### Robustness improvements caught during review

- **`endpoint_uri` reflects the active provider** — overridden as a property so diagnostic tooling (metrics, logs, request IDs) reading `w3.provider.endpoint_uri` after rotation observes the correct endpoint.
- **Empty `rpc_urls` raises `ValueError` at construction** instead of silently producing a broken provider that fails on first use.
- **Lock coverage** — `_mark_rpc_backoff` and `_is_rpc_healthy` now hold the lock; switched to `RLock` so they're callable from within `_rotate`.
- **Unknown-category errors log a warning** before re-raising, surfacing novel transport issues that previously fell through silently.
- **`classify_error` returns `Literal[...]`** so the stringly-typed switches in `make_request` and `_handle_error_and_rotate` are mypy-checkable.
- **No more redundant `classify_error` calls** — `make_request` passes the precomputed category through to `_handle_error_and_rotate`.

## Test plan

- [x] Existing 75 rotation tests migrated from middleware API to provider API; all pass
- [x] Existing 36 chainlist tests pass
- [x] Existing 80 ethereum unit tests pass (including `test_api_creation_poa`, `test_attribute_dict_translator`)
- [x] New regression tests:
  - [x] `test_attribute_dict_wrapping_on_rotation_path` — guards the original regression
  - [x] `test_user_injected_middleware_runs_on_rotation_path` — verifies user middleware at `layer=0` runs
  - [x] `test_eth_send_transaction_not_retried_on_rate_limit` — full write-safety coverage
  - [x] `test_wsaeconnreset_rotates_to_next_provider` — Windows errno-10054 path through the new provider, preserving the v2.2.4 motivation (#887)
  - [x] `test_poa_middleware_transforms_response_on_rotation_path` — PoA at `inject(layer=0)` works on rotation path
- [x] black, isort, flake8, copyright, darglint, dependencies-check, pylint (10/10)
- [x] `aea-ci generate-api-docs --check` clean
- [x] `aea-ci check-doc-hashes` clean
- [ ] CI passes (will be confirmed when this PR runs)
- [ ] Smoke-test in open-autonomy by removing the `open-aea-ledger-ethereum = "2.2.3"` pin from valory-xyz/quickstart@1610beb and confirming `TxSettler.settle()` works through the new provider path

## Refs

- Reverts the bypass behavior introduced in #887 while preserving its Windows RPC reliability fix (covered by the new errno-10054 regression test)
- Fixes the regression observed by valory-xyz/quickstart@1610beb (workaround pin can be dropped once a release containing this fix lands)