### PR TITLE
chore: bump version to v2.2.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,18 @@
 # Release History - open AEA
 
+## 2.2.5 (2026-05-08)
+
+Plugins:
+
+- `open-aea-ledger-ethereum`: refactors `RPCRotationMiddleware` into a `RotatingHTTPProvider` (an `HTTPProvider` subclass) and constructs `Web3(RotatingHTTPProvider(...))` directly in `EthereumApi.__init__`. Rotation now lives at the transport layer, so the standard web3 middleware chain — defaults plus any user-injected middleware — runs untouched on every call. Fixes the v2.2.4 regression where `ledger_api.api.eth.<method>(...)` returned plain dicts instead of `AttributeDict`, breaking attribute access (e.g. `receipt.blockNumber`) for downstream consumers reaching into the underlying web3 handle directly (open-autonomy `TxSettler.settle()`, etc.). All inner middleware (`AttributeDictMiddleware`, `ENSNameToAddressMiddleware`, `FormattingMiddleware`, `BufferedGasEstimateMiddleware`, `GasPriceStrategyMiddleware`, and any user-injected `inject(layer=0)` middleware) — silently dead under the v2.2.4 bypass — now run normally. `ExtraDataToPOAMiddleware` reverts to its standard placement at `inject(layer=0)`. #889
+- `open-aea-ledger-ethereum`: `RotatingHTTPProvider.endpoint_uri` is overridden as a property that reflects the *currently active* RPC URL, so diagnostic tooling (metrics, logs, request IDs) reading `w3.provider.endpoint_uri` post-rotation observes the correct endpoint instead of the URL passed to `super().__init__`. #889
+- `open-aea-ledger-ethereum`: `RotatingHTTPProvider` raises `ValueError` at construction if `rpc_urls` (after Chainlist enrichment) is empty, replacing the silent failure that previously surfaced as an opaque `requests` error on the first RPC call. #889
+- `open-aea-ledger-ethereum`: `_mark_rpc_backoff` and `_is_rpc_healthy` now run under the rotation lock (switched to `threading.RLock` so they remain callable from inside `_rotate`), closing a torn-read window on `_backoff_until` under concurrent error/rotation events. Unknown-category errors emit a `WARNING` log before re-raising so novel transport failures are no longer silent. `classify_error` now returns a `Literal[...]` so the categorical switches in `make_request` / `_handle_error_and_rotate` are mypy-checkable. #889
+
+Tooling:
+
+- `strategy.ini`: loosens the `urllib3` license-whitelist pin from `==2.6.3` to `>=2.6.3,<3` to track minor upgrades that `requests` resolves transitively. Resolves the `liccheck` CI failure where `requests` pulled `urllib3 2.7.0` while the strategy still authorized only `2.6.3`. #889
+
 ## 2.2.4 (2026-05-07)
 
 Plugins:

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.4 "open-aea-cli-ipfs<3.0.0,>=2.2.4"
+RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.5 "open-aea-cli-ipfs<3.0.0,>=2.2.5"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v2.2.4/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v2.2.5/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:2.2.4
+DOCKER_IMAGE_TAG=valory/open-aea-develop:2.2.5
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,6 +9,32 @@ Below we describe the additional manual steps required to upgrade between differ
 
 ### Upgrade guide
 
+## `v2.2.4` to `v2.2.5`
+
+This is a non-breaking patch release. It fixes a v2.2.4 regression where `ledger_api.api.eth.<method>(...)` returned plain dicts instead of `AttributeDict` for downstream consumers reaching into the underlying web3 handle directly (most notably open-autonomy's `TxSettler.settle()`, which crashes on `receipt.blockNumber` attribute access). The fix is a structural refactor of RPC rotation; every public surface (`EthereumApi`, `ledger_api.api`, the web3 instance, the rotation behaviour) keeps the same semantics it had before v2.2.4.
+
+### `open-aea-ledger-ethereum` — RPC rotation moved from middleware to provider
+
+`RPCRotationMiddleware` (a Web3 middleware) has been replaced by `RotatingHTTPProvider` (an `HTTPProvider` subclass). `EthereumApi.__init__` now does `Web3(RotatingHTTPProvider(rpc_urls, ...))` instead of constructing a plain `HTTPProvider` and registering rotation as a middleware.
+
+The motivation: as a middleware, rotation had to call pooled providers' `make_request` directly to retry against different endpoints — which bypassed every other web3 middleware on every call. v2.2.4 patched `ExtraDataToPOAMiddleware` and `AttributeDictTranslator` defensively but left the bypass in place, so `AttributeDictMiddleware` (and several other defaults) silently stopped running. Putting rotation at the transport layer puts it *under* the entire web3 chain — every request runs through the full middleware stack, and only the underlying socket changes when rotation occurs.
+
+Practical impact for downstream consumers:
+
+- Code that calls `ledger_api.api.eth.<method>(...)` directly (e.g. `eth.get_transaction_receipt`, `eth.send_raw_transaction`) once again receives `AttributeDict`-wrapped responses, so attribute access (`receipt.blockNumber`, `tx.hash`, etc.) works as in v2.2.3 and earlier.
+- User-injected middleware at `inject(layer=0)` — silently bypassed under v2.2.4 — runs again.
+- `ExtraDataToPOAMiddleware` returns to its standard `inject(layer=0)` placement. If you were programmatically inspecting `web3.middleware_onion` and asserting PoA was at the *outermost* position (the v2.2.4 workaround), revert that assertion to the pre-2.2.4 expectation, or look it up by name.
+- `web3.provider.endpoint_uri` now reflects the currently active RPC URL after rotation rather than the first URL passed at construction.
+- Constructing an `EthereumApi` (or `RotatingHTTPProvider` directly) with an empty `rpc_urls` list now raises `ValueError` at construction instead of failing on the first RPC call.
+
+If you were pinning `open-aea-ledger-ethereum = "2.2.3"` to work around the v2.2.4 regression, you can drop the pin and upgrade to `2.2.5`.
+
+### Concrete upgrade steps
+
+- `pip install --upgrade "open-aea[all]==2.2.5"` (and the same `2.2.5` pin for any `open-aea-*` plugin you use, in particular `open-aea-ledger-ethereum`).
+- `aea --version` should report `2.2.5`.
+- No agent / package / config edits are required.
+
 ## `v2.2.3` to `v2.2.4`
 
 This is a non-breaking patch release. The fixes target the `open-aea-ledger-ethereum` RPC rotation middleware and primarily affect Windows deployments, but two changes (PoA middleware ordering and `AttributeDictTranslator.to_dict` accepting plain `dict`) are global to all Ethereum users. Both are backwards-compatible.

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.4
+RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.5
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-ci-helpers/setup.py
+++ b/plugins/aea-ci-helpers/setup.py
@@ -31,7 +31,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ci-helpers",
-    version="2.2.4",
+    version="2.2.5",
     author="Valory AG",
     license="Apache-2.0",
     description="CI helper utilities for AEA-based projects.",

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-cli-benchmark",
-    version="2.2.4",
+    version="2.2.5",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -34,7 +34,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-cli-ipfs",
-    version="2.2.4",
+    version="2.2.5",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-dev-helpers/setup.py
+++ b/plugins/aea-dev-helpers/setup.py
@@ -31,7 +31,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-dev-helpers",
-    version="2.2.4",
+    version="2.2.5",
     author="Valory AG",
     license="Apache-2.0",
     description="Development and release helper utilities for AEA-based projects.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -33,7 +33,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="2.2.4",
+    version="2.2.5",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum-hwi/setup.py
+++ b/plugins/aea-ledger-ethereum-hwi/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-ethereum-hwi",
-    version="2.2.4",
+    version="2.2.5",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and support for hardware wallet interactions.",
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "open-aea>=2.0.0, <3.0.0",
         "eth-account>=0.13.0,<0.14.0",
-        "open-aea-ledger-ethereum~=2.2.4",
+        "open-aea-ledger-ethereum~=2.2.5",
         "ledgerwallet==0.1.3",
     ],
     tests_require=["pytest>=7.0,<10"],

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -33,7 +33,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="2.2.4",
+    version="2.2.5",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -37,7 +37,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="2.2.4",
+    version="2.2.5",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",
@@ -51,7 +51,7 @@ setup(
         ]
     },
     python_requires=">=3.10,<3.15",
-    install_requires=["open-aea-ledger-cosmos~=2.2.4", "requests>=2.32.5,<3"],
+    install_requires=["open-aea-ledger-cosmos~=2.2.5", "requests>=2.32.5,<3"],
     extras_require={
         "test_tools": ["pytest>=7.0,<10", "docker==7.1.0"],
     },

--- a/plugins/aea-ledger-solana/setup.py
+++ b/plugins/aea-ledger-solana/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-solana",
-    version="2.2.4",
+    version="2.2.5",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of solana.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "open-aea"
-version = "2.2.4"
+version = "2.2.5"
 description = "Open AEA Framework"
 authors = ["developer-valory <develope@valory.xyz>"]
 license = "Apache-2.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==2.2.4 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==2.2.5 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==2.2.4 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==2.2.5 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "2.2.4"
+      template: "2.2.5"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "2.2.4"
+          template: "2.2.5"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG=C.UTF-8
 RUN apt update && apt upgrade -y && apt install -y python3-dev python3-pip && apt autoremove && apt autoclean
 
 RUN pip3 install --upgrade pip
-RUN pip3 install "open-aea[all]==2.2.4" open-aea-cli-ipfs==2.2.4
+RUN pip3 install "open-aea[all]==2.2.5" open-aea-cli-ipfs==2.2.5
 
 COPY user-image/openssl.cnf /etc/ssl
 

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:2.2.4
+DOCKER_IMAGE_TAG=valory/open-aea-user:2.2.5
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
Stack PR on top of #889 — bumps `open-aea` and every `open-aea-*` plugin to **2.2.5**, plus the matching Docker images, install scripts, and skaffold manifests. HISTORY.md and docs/upgrading.md document the user-visible changes for the release, all sourced from #889.

> Base branch is **`fix/rpc-rotation-as-provider`** (the parent PR), not `main`. After #889 merges, change the base to `main` (or it will retarget automatically once the parent is merged) and merge this one to ship 2.2.5.

## What's in v2.2.5

The release is exclusively the v2.2.4 regression fix. From #889:

- `open-aea-ledger-ethereum`: refactors `RPCRotationMiddleware` (a Web3 middleware) into `RotatingHTTPProvider` (an `HTTPProvider` subclass). `EthereumApi.__init__` now does `Web3(RotatingHTTPProvider(...))` directly. Rotation lives at the transport layer, so the standard web3 middleware chain — defaults plus any user-injected middleware — runs untouched on every call.
- Fixes the v2.2.4 regression where `ledger_api.api.eth.<method>(...)` returned plain dicts instead of `AttributeDict`, breaking attribute access (e.g. `receipt.blockNumber`) for downstream consumers like open-autonomy's `TxSettler.settle()`.
- Restores every default web3 middleware (`AttributeDictMiddleware`, `ENSNameToAddressMiddleware`, `FormattingMiddleware`, `BufferedGasEstimateMiddleware`, `GasPriceStrategyMiddleware`) and any user-injected `inject(layer=0)` middleware — all silently disabled under the v2.2.4 bypass.
- `ExtraDataToPOAMiddleware` reverts to its standard placement at `inject(layer=0)`.
- `RotatingHTTPProvider.endpoint_uri` is overridden as a property reflecting the active RPC URL, so diagnostic tooling reading `w3.provider.endpoint_uri` post-rotation observes the correct endpoint.
- Empty `rpc_urls` raises `ValueError` at construction instead of silently producing a broken provider.
- `_mark_rpc_backoff` and `_is_rpc_healthy` now run under the rotation lock; switched to `RLock` so they're callable from inside `_rotate`.
- Unknown-category errors emit a `WARNING` log before re-raising so novel transport failures aren't silent.
- `classify_error` returns `Literal[...]` for mypy-checkable categorical switches.

Tooling: loosens the `urllib3` license-whitelist pin from `==2.6.3` to `>=2.6.3,<3` to track the version `requests` resolves transitively (CI fix).

## Test plan

- [x] `aea --version` reports `2.2.5`
- [x] All 22 version-bearing files updated (same shape as the v2.2.4 bump in #888)
- [x] HISTORY.md entry added with release date `2026-05-08`
- [x] docs/upgrading.md `v2.2.4 → v2.2.5` upgrade guide added
- [x] black, isort, flake8, copyright, darglint, dependencies-check all green locally
- [x] `aea-ci check-doc-hashes` clean
- [x] 191 unit tests still pass (inherited from #889)
- [ ] CI passes
- [ ] Smoke-test with open-autonomy by removing the `open-aea-ledger-ethereum = "2.2.3"` pin from valory-xyz/quickstart@1610beb and confirming `TxSettler.settle()` works through the v2.2.5 provider path

## Refs

- Builds on #889 (rotation refactor)
- Fixes the v2.2.4 regression observed by valory-xyz/quickstart@1610beb (workaround pin can be dropped once 2.2.5 ships)