### PR TITLE
chore: release v2.2.8

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # Release History - open AEA
 
+## 2.2.8 (2026-06-08)
+
+Plugins:
+
+- `open-aea-ledger-ethereum` (`try_get_gas_pricing`): eliminates a thread-safety race that caused `tx["gasPrice"]` to be set to a dict (e.g. `{"maxFeePerGas": ..., "maxPriorityFeePerGas": ...}`) instead of an integer. The previous implementation temporarily mutated `w3.eth._gas_price_strategy` via `set_gas_price_strategy` / `generate_gas_price()` / restore. A concurrent `build_transaction` call would invoke `fill_transaction_defaults` inside that window, observe a non-None `generate_gas_price()` result, force `is_dynamic_fee_transaction = False`, and store the entire strategy-returned dict as `tx["gasPrice"]`. Downstream arithmetic on that dict crashed with `TypeError: unsupported operand type(s) for *: 'dict' and 'float'`, surfacing as an HTTP 500 in Pearl's backend. Fix calls the strategy callable directly — `gas_price_strategy_callable(self._api, None)` — which is what `generate_gas_price()` did internally but never touches `w3.eth._gas_price_strategy`. The race window is eliminated. #921
+
 ## 2.2.7 (2026-05-27)
 
 Framework:

--- a/aea/__version__.py
+++ b/aea/__version__.py
@@ -23,7 +23,7 @@
 __title__ = "open-aea"
 __description__ = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 __url__ = "https://github.com/valory-xyz/open-aea.git"
-__version__ = "2.2.7"
+__version__ = "2.2.8"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021 Valory AG, 2019 Fetch.AI Limited"

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.7 "open-aea-cli-ipfs<3.0.0,>=2.2.7"
+RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.8 "open-aea-cli-ipfs<3.0.0,>=2.2.8"
 
 # directories and aea cli config
 WORKDIR /home/agents

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -11,7 +11,7 @@ The example uses the `fetchai/my_first_aea` project. You will likely want to mod
 Install subversion, then download the example directory to your local working directory
 
 ``` bash
-svn checkout https://github.com/valory-xyz/open-aea/tags/v2.2.7/packages packages
+svn checkout https://github.com/valory-xyz/open-aea/tags/v2.2.8/packages packages
 ```
 
 ### Modify scripts

--- a/develop-image/docker-env.sh
+++ b/develop-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-develop:2.2.7
+DOCKER_IMAGE_TAG=valory/open-aea-develop:2.2.8
 # DOCKER_IMAGE_TAG=valory/open-aea-develop:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,6 +9,22 @@ Below we describe the additional manual steps required to upgrade between differ
 
 ### Upgrade guide
 
+## `v2.2.7` to `v2.2.8`
+
+This is a non-breaking patch release. It contains a single fix: a thread-safety race in `open-aea-ledger-ethereum`'s `try_get_gas_pricing` that caused `tx["gasPrice"]` to be set to a dict instead of an integer under concurrent load (cf. #921).
+
+### `open-aea-ledger-ethereum` — `try_get_gas_pricing` no longer mutates the shared `Web3` instance
+
+`try_get_gas_pricing` previously called `w3.eth.set_gas_price_strategy` / `generate_gas_price()` / restore to invoke the strategy. This created a race window: a concurrent `build_transaction` call that reached `fill_transaction_defaults` while the strategy was temporarily set would observe a non-None `generate_gas_price()` result, force `is_dynamic_fee_transaction = False`, and store the entire strategy-returned dict as `tx["gasPrice"]` (e.g. `{"maxFeePerGas": 2000000000, "maxPriorityFeePerGas": 300000000}`). Downstream code then crashed with `TypeError: unsupported operand type(s) for *: 'dict' and 'float'`.
+
+The fix calls the strategy callable directly — `gas_price_strategy_callable(self._api, None)` — which never touches `w3.eth._gas_price_strategy`. No caller-visible behaviour change under single-threaded use.
+
+### Concrete upgrade steps
+
+- `pip install --upgrade "open-aea-ledger-ethereum==2.2.8"` (and the same `2.2.8` pin for any other `open-aea-*` plugin you use).
+- `aea --version` should report `2.2.8`.
+- No agent / package / config edits are required.
+
 ## `v2.2.6` to `v2.2.7`
 
 This is a non-breaking patch release covering: upstream hooks that let open-autonomy drop three local workarounds (cf. [open-autonomy#2485](https://github.com/valory-xyz/open-autonomy/issues/2485), open-aea #918), a fix for double-formatted agent log lines (cf. #914 / #917), an env-var encoding fix for service overrides with bash-unsafe dict keys (cf. [open-autonomy#2243](https://github.com/valory-xyz/open-autonomy/issues/2243), #915), an `aea-ci check-dependencies` fix for grouped and optional-without-`extras` pyproject deps (#916), and a docs rewrite of `docs/connection-resilience.md` (#912).

--- a/examples/tac_deploy/Dockerfile
+++ b/examples/tac_deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache go
 
 # aea installation
 RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.7
+RUN pip install --upgrade --force-reinstall open-aea[all]==2.2.8
 
 # directories and aea cli config
 COPY /.aea /home/.aea

--- a/plugins/aea-ci-helpers/setup.py
+++ b/plugins/aea-ci-helpers/setup.py
@@ -31,7 +31,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ci-helpers",
-    version="2.2.7",
+    version="2.2.8",
     author="Valory AG",
     license="Apache-2.0",
     description="CI helper utilities for AEA-based projects.",

--- a/plugins/aea-cli-benchmark/setup.py
+++ b/plugins/aea-cli-benchmark/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-cli-benchmark",
-    version="2.2.7",
+    version="2.2.8",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for AEA framework benchmarking.",

--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -34,7 +34,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-cli-ipfs",
-    version="2.2.7",
+    version="2.2.8",
     author="Valory AG",
     license="Apache-2.0",
     description="CLI extension for open AEA framework wrapping IPFS functionality.",

--- a/plugins/aea-dev-helpers/setup.py
+++ b/plugins/aea-dev-helpers/setup.py
@@ -31,7 +31,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-dev-helpers",
-    version="2.2.7",
+    version="2.2.8",
     author="Valory AG",
     license="Apache-2.0",
     description="Development and release helper utilities for AEA-based projects.",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -33,7 +33,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-cosmos",
-    version="2.2.7",
+    version="2.2.8",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Cosmos.",

--- a/plugins/aea-ledger-ethereum-hwi/setup.py
+++ b/plugins/aea-ledger-ethereum-hwi/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-ethereum-hwi",
-    version="2.2.7",
+    version="2.2.8",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and support for hardware wallet interactions.",
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "open-aea>=2.0.0, <3.0.0",
         "eth-account>=0.13.0,<0.14.0",
-        "open-aea-ledger-ethereum~=2.2.7",
+        "open-aea-ledger-ethereum~=2.2.8",
         "ledgerwallet==0.1.3",
     ],
     tests_require=["pytest>=7.0,<10"],

--- a/plugins/aea-ledger-ethereum/setup.py
+++ b/plugins/aea-ledger-ethereum/setup.py
@@ -33,7 +33,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-ethereum",
-    version="2.2.7",
+    version="2.2.8",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of Ethereum.",

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -37,7 +37,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-fetchai",
-    version="2.2.7",
+    version="2.2.8",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger API of Fetch.AI.",
@@ -51,7 +51,7 @@ setup(
         ]
     },
     python_requires=">=3.10,<3.15",
-    install_requires=["open-aea-ledger-cosmos~=2.2.7", "requests>=2.32.5,<3"],
+    install_requires=["open-aea-ledger-cosmos~=2.2.8", "requests>=2.32.5,<3"],
     extras_require={
         "test_tools": ["pytest>=7.0,<10", "docker==7.1.0"],
     },

--- a/plugins/aea-ledger-solana/setup.py
+++ b/plugins/aea-ledger-solana/setup.py
@@ -32,7 +32,7 @@ def _read_long_description() -> str:
 
 setup(
     name="open-aea-ledger-solana",
-    version="2.2.7",
+    version="2.2.8",
     author="Valory AG",
     license="Apache-2.0",
     description="Python package wrapping the public and private key cryptography and ledger api of solana.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "open-aea"
-version = "2.2.7"
+version = "2.2.8"
 description = "Open AEA Framework"
 authors = ["developer-valory <develope@valory.xyz>"]
 license = "Apache-2.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,7 +34,7 @@ function instal_choco_golang_gcc {
 }
 function install_aea {
 	echo "Install aea"
-    $output=pip install open-aea[all]==2.2.7 --force --no-cache-dir 2>&1 |out-string;
+    $output=pip install open-aea[all]==2.2.8 --force --no-cache-dir 2>&1 |out-string;
     if ($LastExitCode -ne 0) {
         echo $output
         echo "AEA install failed!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ function is_python_version_ok() {
 
 function install_aea (){
 	echo "Install AEA"
-	output=$(pip3 install --user open-aea[all]==2.2.7 --force --no-cache-dir)
+	output=$(pip3 install --user open-aea[all]==2.2.8 --force --no-cache-dir)
 	if [[  $? -ne 0 ]];
 	then
 		echo "$output"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   tagPolicy:
     envTemplate:
-      template: "2.2.7"
+      template: "2.2.8"
   artifacts:
   - image: valory/open-aea-develop
     docker:
@@ -24,7 +24,7 @@ profiles:
     build:
       tagPolicy:
         envTemplate:
-          template: "2.2.7"
+          template: "2.2.8"
       artifacts:
       - image: valory/open-aea-docs
         docker:

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG=C.UTF-8
 RUN apt update && apt upgrade -y && apt install -y python3-dev python3-pip && apt autoremove && apt autoclean
 
 RUN pip3 install --upgrade pip
-RUN pip3 install "open-aea[all]==2.2.7" open-aea-cli-ipfs==2.2.7
+RUN pip3 install "open-aea[all]==2.2.8" open-aea-cli-ipfs==2.2.8
 
 COPY user-image/openssl.cnf /etc/ssl
 

--- a/user-image/docker-env.sh
+++ b/user-image/docker-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Swap the following lines if you want to work with 'latest'
-DOCKER_IMAGE_TAG=valory/open-aea-user:2.2.7
+DOCKER_IMAGE_TAG=valory/open-aea-user:2.2.8
 # DOCKER_IMAGE_TAG=valory/open-aea-user:latest
 
 DOCKER_BUILD_CONTEXT_DIR=..


### PR DESCRIPTION
## Release summary

Version number: **2.2.8**

## Release details

Bundles one PR merged to `main` since `v2.2.7`:

- **#921 — thread-safety fix in `try_get_gas_pricing`** (`open-aea-ledger-ethereum`). `try_get_gas_pricing` temporarily mutated `w3.eth._gas_price_strategy` via `set_gas_price_strategy` / `generate_gas_price()` / restore. A concurrent `build_transaction` call reaching `fill_transaction_defaults` inside that window observed a non-None `generate_gas_price()` result, forced `is_dynamic_fee_transaction = False`, and stored the entire strategy-returned dict as `tx["gasPrice"]` (e.g. `{"maxFeePerGas": 2000000000, "maxPriorityFeePerGas": 300000000}`). Downstream arithmetic crashed with `TypeError: unsupported operand type(s) for *: 'dict' and 'float'`, surfacing as an HTTP 500 in Pearl's backend. Fix calls the strategy callable directly — `gas_price_strategy_callable(self._api, None)` — which never touches `w3.eth._gas_price_strategy`.

Full breakdown is in the v2.2.8 section of `HISTORY.md`.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side), from a fix/feat/refactor/docs/chore branch
- [x] Lint and unit tests pass locally and in CI
- [x] I have checked the fingerprint hashes are correct by running (`aea packages lock --check`)
- [x] I have regenerated the latest API docs
- [x] I built the documentation and updated it with the latest changes
- [x] I have added an item in `HISTORY.md` for this release
- [x] I bumped the version number in the `aea/__version__.py` file.
- [ ] I bumped the version number in every Docker image of the repo and published it. Also, I built and published them with tag `latest` (check the READMEs of [`aea-develop`](../develop-image/README.md#publish) and [`aea-user`](../user-image/README.md#publish))
- [ ] I have pushed the latest packages to the registry.
- [ ] I have uploaded the latest `aea` to PyPI.
- [ ] I have uploaded the latest plugins to PyPI.

The four unchecked items are post-merge / post-tag actions. PyPI publish (framework + 9 plugins) is automated by `.github/workflows/release.yml` on `release: published`, so they happen once the v2.2.8 GitHub Release is cut against the merge commit. Docker images and registry pushes are the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)